### PR TITLE
fix: address post-merge Copilot review comments from PR #29

### DIFF
--- a/src/generate_container_packages/builder.py
+++ b/src/generate_container_packages/builder.py
@@ -63,8 +63,13 @@ def build_package(
 
         return deb_file
 
+    except BuildError:
+        # Re-raise expected build errors without preservation message
+        # (cleanup still happens in finally block)
+        raise
+
     except Exception:
-        # Preserve build directory on error if requested
+        # Preserve build directory on unexpected error if requested
         if keep_temp:
             print(f"Build directory preserved at: {build_dir}")
         raise
@@ -75,9 +80,7 @@ def build_package(
             shutil.rmtree(build_dir)
 
 
-def prepare_build_directory(
-    app_def: AppDefinition, rendered_dir: Path, source_dir: Path
-) -> None:
+def prepare_build_directory(app_def: AppDefinition, rendered_dir: Path, source_dir: Path) -> None:
     """Prepare build directory with all required files.
 
     Args:
@@ -237,14 +240,11 @@ def run_dpkg_buildpackage(source_dir: Path) -> subprocess.CompletedProcess:
 
     except FileNotFoundError as e:
         raise BuildError(
-            "dpkg-buildpackage not found.\n"
-            "Install with: sudo apt install dpkg-dev debhelper"
+            "dpkg-buildpackage not found.\nInstall with: sudo apt install dpkg-dev debhelper"
         ) from e
 
 
-def collect_artifacts(
-    build_dir: Path, output_dir: Path, pkg_name: str, version: str
-) -> list[Path]:
+def collect_artifacts(build_dir: Path, output_dir: Path, pkg_name: str, version: str) -> list[Path]:
     """Collect build artifacts and move to output directory.
 
     Args:

--- a/src/generate_container_packages/cli.py
+++ b/src/generate_container_packages/cli.py
@@ -102,9 +102,7 @@ def main() -> int:
             # Step 4: Build package
             output_dir = Path(args.output).resolve()
             logger.info(f"Building package (output: {output_dir})...")
-            deb_file = build_package(
-                app_def, rendered_dir, output_dir, keep_temp=args.keep_temp
-            )
+            deb_file = build_package(app_def, rendered_dir, output_dir, keep_temp=args.keep_temp)
             logger.info(f"✓ Package built successfully: {deb_file}")
 
             # Success message
@@ -122,13 +120,13 @@ def main() -> int:
 
     except ValidationError as e:
         logger.error("Validation failed:")
-        print(f"\nERROR: Validation failed\n", file=sys.stderr)
+        print("\nERROR: Validation failed\n", file=sys.stderr)
         print(str(e), file=sys.stderr)
         return EXIT_VALIDATION_ERROR
 
     except TemplateError as e:
         logger.error(f"Template rendering failed: {e}")
-        print(f"\nERROR: Template rendering failed\n", file=sys.stderr)
+        print("\nERROR: Template rendering failed\n", file=sys.stderr)
         print(str(e), file=sys.stderr)
         if args.debug:
             traceback.print_exc()
@@ -136,7 +134,7 @@ def main() -> int:
 
     except BuildError as e:
         logger.error(f"Package build failed: {e}")
-        print(f"\nERROR: Package build failed\n", file=sys.stderr)
+        print("\nERROR: Package build failed\n", file=sys.stderr)
         print(str(e), file=sys.stderr)
         if args.debug:
             traceback.print_exc()
@@ -148,7 +146,7 @@ def main() -> int:
 
     except Exception as e:
         logger.error(f"Unexpected error: {e}")
-        print(f"\nERROR: Unexpected error\n", file=sys.stderr)
+        print("\nERROR: Unexpected error\n", file=sys.stderr)
         print(str(e), file=sys.stderr)
         if args.debug or args.verbose:
             traceback.print_exc()
@@ -213,9 +211,7 @@ def create_argument_parser() -> argparse.ArgumentParser:
     )
 
     # Version
-    parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
-    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
 
     return parser
 
@@ -257,15 +253,13 @@ def check_dependencies() -> None:
     except ImportError as e:
         module_name = getattr(e, "name", None) or "unknown module"
         raise ImportError(
-            f"Missing required Python dependency: {module_name}\n"
-            "Install with: pip install -e ."
+            f"Missing required Python dependency: {module_name}\nInstall with: pip install -e ."
         ) from e
 
     # Check system tools (dpkg-buildpackage)
     if not shutil.which("dpkg-buildpackage"):
         raise FileNotFoundError(
-            "dpkg-buildpackage not found.\n"
-            "Install with: sudo apt install dpkg-dev debhelper"
+            "dpkg-buildpackage not found.\nInstall with: sudo apt install dpkg-dev debhelper"
         )
 
 


### PR DESCRIPTION
## Summary

Addresses post-merge Copilot review comments on PR #29 that were identified after the merge.

**Fixes:**
1. **Exception handling improvement** ([#29 comment](https://github.com/hatlabs/container-packaging-tools/pull/29#discussion_r2519968168))
   - Separated `BuildError` (expected) from unexpected exceptions in `build_package()`
   - Prevents misleading "Build directory preserved" messages for expected build errors
   - Unexpected errors still trigger preservation message when `--keep-temp` is used

2. **Code style cleanup**
   - Removed unnecessary f-string prefixes from error messages in cli.py
   - Fixed linting warnings identified during review

## Changes

- `builder.py`: Added separate exception handler for `BuildError` 
- `cli.py`: Removed 4 unnecessary f-string prefixes

## Test Results

- ✅ All 102 tests pass
- ✅ Linting checks pass
- ✅ Formatting checks pass  
- ✅ Type checks pass

## Related

- Original PR: #29
- Copilot review comment: https://github.com/hatlabs/container-packaging-tools/pull/29#discussion_r2519968168

🤖 Generated with [Claude Code](https://claude.com/claude-code)