### PR TITLE
ci: separate CI testing from release draft creation

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,15 +1,20 @@
-name: Build and Draft Release
+name: Draft Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
-  build-and-release:
+  draft-release:
     runs-on: ubuntu-latest
+    # Only run if CI workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -58,40 +63,18 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
-    - name: Install uv
+    - name: Download package artifacts from CI workflow
       if: steps.check_release.outputs.skip == 'false'
-      uses: astral-sh/setup-uv@v5
+      uses: actions/download-artifact@v4
       with:
-        enable-cache: true
+        name: debian-packages
+        path: release-artifacts
+        github-token: ${{ github.token }}
+        run-id: ${{ github.event.workflow_run.id }}
 
-    - name: Install dependencies
+    - name: List downloaded packages
       if: steps.check_release.outputs.skip == 'false'
       run: |
-        uv sync --dev
-
-    - name: Run tests
-      if: steps.check_release.outputs.skip == 'false'
-      run: |
-        uv run pytest
-
-    - name: Install Debian build tools
-      if: steps.check_release.outputs.skip == 'false'
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y dpkg-dev debhelper dh-python python3-all python3-setuptools
-
-    - name: Build Debian package
-      if: steps.check_release.outputs.skip == 'false'
-      run: |
-        dpkg-buildpackage -us -uc
-
-    - name: Move packages to release directory
-      if: steps.check_release.outputs.skip == 'false'
-      run: |
-        mkdir -p release-artifacts
-        mv ../*.deb release-artifacts/ || echo "Warning: No .deb files found"
-        mv ../*.buildinfo release-artifacts/ || echo "Warning: No .buildinfo files found"
-        mv ../*.changes release-artifacts/ || echo "Warning: No .changes files found"
         ls -lh release-artifacts/
 
     - name: Create draft release

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ venv.bak/
 *~
 .DS_Store
 
+# Claude Code local settings
+.claude/
+
 # Debian packaging artifacts (from testing)
 *.deb
 *.buildinfo


### PR DESCRIPTION
## Summary

- Refactored GitHub Actions workflows to separate testing from release drafting
- CI workflow now handles all testing and package building
- Draft release workflow triggers after CI succeeds and downloads package artifacts
- Added `.claude/` to `.gitignore` for local IDE settings

## Changes

**Workflow Improvements:**
- `test.yml` (CI workflow) now owns all testing and package building responsibilities
- `draft-release.yml` now triggers via `workflow_run` after CI succeeds
- Draft release downloads package artifacts from CI instead of rebuilding (eliminates duplication)
- Fixed the CI failure where draft-release was redundantly building packages

**Other:**
- Added `.claude/` directory to `.gitignore` for local Claude Code settings

## Benefits

1. **Cleaner separation of concerns:** Testing vs releasing are now distinct workflows
2. **No duplication:** Package is built once in CI, reused by draft-release
3. **Faster drafts:** No rebuild needed, just downloads artifacts
4. **Better resource usage:** Reduces CI compute time and complexity

## Test Plan

- [x] Workflow files pass YAML validation
- [ ] CI workflow runs successfully on push to main
- [ ] Draft release workflow triggers after CI completion
- [ ] Package artifacts are correctly downloaded and attached to draft release
- [ ] All checks pass before merge

## Related Issues

Part of issues #20, #21, #23, #24 (docs and polish phase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)