### PR TITLE
fix(ci): use correct APT repository dispatch protocol

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,13 @@ jobs:
       with:
         token: ${{ secrets.REPO_DISPATCH_PAT }}
         repository: hatlabs/apt.hatlabs.fi
-        event-type: container-packaging-tools-release
+        event-type: package-updated
         client-payload: |
           {
-            "package": "container-packaging-tools",
+            "repository": "container-packaging-tools",
+            "distro": "any",
+            "channel": "stable",
+            "component": "main",
             "version": "${{ steps.version.outputs.version }}",
-            "tag_name": "${{ github.event.release.tag_name }}",
             "release_url": "${{ github.event.release.html_url }}"
           }


### PR DESCRIPTION
## Problem

The release workflow was sending dispatch events to apt.hatlabs.fi with an incorrect event type (`container-packaging-tools-release`), causing releases to be silently ignored.

The apt.hatlabs.fi workflow only listens for `package-updated` events, so packages never got added to the APT repository.

## Solution

Updated `.github/workflows/release.yml` to use the new apt.hatlabs.fi dispatch protocol:

**Changed:**
- Event type: `container-packaging-tools-release` → `package-updated`
- Payload format: Now uses `repository`, `distro`, `channel`, `component` fields
- Removed: Unused `tag_name` field

**New payload structure:**
```json
{
  "repository": "container-packaging-tools",
  "distro": "any",
  "channel": "stable",
  "component": "main",
  "version": "X.Y.Z",
  "release_url": "..."
}
```

## Impact

- ✅ Releases now trigger APT repository updates
- ✅ Packages are added to the correct repository
- ✅ Aligns with new apt.hatlabs.fi multi-distribution protocol

Closes #42