### PR TITLE
fix(ci): use github.repository variable in dispatch payload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         event-type: package-updated
         client-payload: |
           {
-            "repository": "container-packaging-tools",
+            "repository": "${{ github.repository }}",
             "distro": "any",
             "channel": "stable",
             "component": "main",


### PR DESCRIPTION
Fixes critical bug discovered in PR #48 review.

The dispatch payload had incomplete repository field missing organization prefix.

Changed: repository = 'container-packaging-tools'
To: repository = '${{ github.repository }}'

This expands to 'hatlabs/container-packaging-tools' which is required for 
apt.hatlabs.fi GitHub API calls to succeed.

Without this fix, releases are silently ignored by apt.hatlabs.fi because
the API call fails with 404.

Also ensures consistency with halos-marine-containers which uses the correct 
format in PR #12.

After merge, test with a release to verify end-to-end workflow.