### PR TITLE
fix(ci): add missing pybuild-plugin-pyproject build dependency

### DIFF
--- a/.github/scripts/build-deb-package.sh
+++ b/.github/scripts/build-deb-package.sh
@@ -6,8 +6,9 @@ echo "🏗️  Building Debian package..."
 # Install build dependencies
 echo "📦 Installing build dependencies..."
 sudo apt-get update -qq
-sudo apt-get install -y -qq build-essential dpkg-dev debhelper dh-python python3-all \
-  python3-pydantic python3-jinja2 python3-yaml nodejs npm >/dev/null 2>&1
+sudo apt-get install -y -qq build-essential dpkg-dev debhelper dh-python \
+  pybuild-plugin-pyproject python3-all python3-pydantic python3-jinja2 python3-yaml \
+  nodejs npm >/dev/null 2>&1
 
 # Build the package
 echo "🔨 Building package..."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq build-essential dpkg-dev debhelper dh-python \
-            python3-all python3-pydantic python3-jinja2 python3-yaml nodejs npm \
-            devscripts >/dev/null 2>&1
+            pybuild-plugin-pyproject python3-all python3-pydantic python3-jinja2 \
+            python3-yaml nodejs npm devscripts >/dev/null 2>&1
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v2


### PR DESCRIPTION
Fixes build failure where dpkg-buildpackage reported unmet dependency: pybuild-plugin-pyproject

This is required for Python packages that use pyproject.toml for their build configuration.

Fixes the main branch CI/CD workflow that was failing when trying to build the Debian package.