### PR TITLE
fix: use repository variables and add missing build dependency

### DIFF
--- a/.github/scripts/build-deb-package.sh
+++ b/.github/scripts/build-deb-package.sh
@@ -7,8 +7,8 @@ echo "🏗️  Building Debian package..."
 echo "📦 Installing build dependencies..."
 sudo apt-get update -qq
 sudo apt-get install -y -qq build-essential dpkg-dev debhelper dh-python \
-  pybuild-plugin-pyproject python3-all python3-pydantic python3-jinja2 python3-yaml \
-  nodejs npm >/dev/null 2>&1
+  pybuild-plugin-pyproject python3-all python3-setuptools python3-pydantic \
+  python3-jinja2 python3-yaml nodejs npm >/dev/null 2>&1
 
 # Build the package
 echo "🔨 Building package..."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,12 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 env:
-  APT_DISTRO: any
-  APT_COMPONENT: main
+  APT_DISTRO: ${{ vars.APT_DISTRO || 'any' }}
+  APT_COMPONENT: ${{ vars.APT_COMPONENT || 'main' }}
 
 jobs:
   test:
@@ -39,8 +42,8 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq build-essential dpkg-dev debhelper dh-python \
-            pybuild-plugin-pyproject python3-all python3-pydantic python3-jinja2 \
-            python3-yaml nodejs npm devscripts >/dev/null 2>&1
+            pybuild-plugin-pyproject python3-all python3-setuptools python3-pydantic \
+            python3-jinja2 python3-yaml nodejs npm devscripts >/dev/null 2>&1
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     types: [published]
 
 env:
-  APT_DISTRO: any
-  APT_COMPONENT: main
+  APT_DISTRO: ${{ vars.APT_DISTRO || 'any' }}
+  APT_COMPONENT: ${{ vars.APT_COMPONENT || 'main' }}
 
 jobs:
   trigger-packaging:


### PR DESCRIPTION
Fixes two issues from the merged PR #52:

## Changes

1. **Use repository variables for APT configuration**
   - Replace hardcoded APT_DISTRO and APT_COMPONENT with `vars.APT_DISTRO` and `vars.APT_COMPONENT`
   - Use fallback defaults: 'any' and 'main'
   - Follows the pattern from cockpit-apt
   - Allows per-repository customization without code changes

2. **Add missing python3-setuptools**
   - Required by debian/control Build-Depends
   - Was missing from both main.yml and build-deb-package.sh
   - Resolves dpkg-buildpackage build failures

3. **Add permissions to main.yml**
   - Add 'contents: write' permission for creating releases

This makes the workflows more flexible and fixes the build failure on main branch.