### PR TITLE
fix: read-version.sh must write to GITHUB_OUTPUT

### DIFF
--- a/.github/scripts/read-version.sh
+++ b/.github/scripts/read-version.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
-set -euo pipefail
-
 # Read version from debian/changelog
-VERSION=$(dpkg-parsechangelog -S Version)
-TAG_VERSION=$(echo "$VERSION" | sed 's/-[^-]*$//')
+# Sets version and tag_version in GitHub output
 
-echo "version=${VERSION}"
-echo "tag_version=${TAG_VERSION}"
+set -e
+
+# Install devscripts if needed
+if ! command -v dpkg-parsechangelog &> /dev/null; then
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq devscripts
+fi
+
+VERSION=$(dpkg-parsechangelog -S Version)
+# Strip Debian revision (everything after the last dash) for tag version
+TAG_VERSION="${VERSION%-*}"
+
+echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
+echo "Version from debian/changelog: $VERSION (tag version: $TAG_VERSION)"


### PR DESCRIPTION
Fixes the workflow failure where version information wasn't being passed between steps.

## Problem
The `read-version.sh` script was only echoing to stdout instead of writing to `$GITHUB_OUTPUT`, which is the correct way to pass values between GitHub Actions steps.

This caused the version to be empty in subsequent steps like `check-release-exists.sh`, leading to errors:
```
.github/scripts/check-release-exists.sh: line 7: 1: Repository required (owner/repo)
```

## Solution
Updated `read-version.sh` to match the cockpit-apt implementation:
- Install devscripts if needed (provides dpkg-parsechangelog)
- Write version variables to `$GITHUB_OUTPUT` for proper GitHub Actions variable passing
- Echo to stdout for logging visibility

This ensures version information flows correctly through the workflow pipeline.