### PR TITLE
fix(ci): use dedicated debtools image instead of devtools

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -11,17 +11,17 @@ runs:
       uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-devtools-${{ hashFiles('docker/Dockerfile.devtools') }}
+        key: ${{ runner.os }}-buildx-debtools-${{ hashFiles('docker/Dockerfile.debtools') }}
         restore-keys: |
-          ${{ runner.os }}-buildx-devtools-
+          ${{ runner.os }}-buildx-debtools-
 
-    - name: Build devtools Docker image
+    - name: Build debtools Docker image
       shell: bash
       run: |
         cd docker
         docker buildx build \
-          --file Dockerfile.devtools \
-          --tag devtools:latest \
+          --file Dockerfile.debtools \
+          --tag debtools:latest \
           --cache-from type=local,src=/tmp/.buildx-cache \
           --cache-to type=local,dest=/tmp/.buildx-cache,mode=max \
           --load \

--- a/.github/scripts/build-deb-package.sh
+++ b/.github/scripts/build-deb-package.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-# Build Debian package (.deb) in devtools container
+# Build Debian package (.deb) in debtools container
 # Container has all build dependencies pre-installed
 
 set -e
 
 echo "Building Debian package in Debian trixie container..."
 
-# Build the package inside devtools container
+# Build the package inside debtools container
 # dpkg-buildpackage writes to .. by convention, so we move files back after
 docker run --rm \
   -v "$(pwd):/workspace" \
   -w /workspace \
-  devtools:latest \
+  debtools:latest \
   bash -c "dpkg-buildpackage -b -uc -us && mv ../*.deb ../*.buildinfo ../*.changes ./ 2>/dev/null || true"
 
 # List generated packages

--- a/docker/Dockerfile.debtools
+++ b/docker/Dockerfile.debtools
@@ -1,0 +1,24 @@
+FROM debian:trixie
+
+# Install Debian packaging tools and build dependencies
+RUN apt-get update && apt-get install -y \
+    debhelper \
+    dh-python \
+    build-essential \
+    fakeroot \
+    devscripts \
+    lintian \
+    dpkg-dev \
+    pybuild-plugin-pyproject \
+    python3-all \
+    python3-setuptools \
+    python3-pydantic \
+    python3-jinja2 \
+    python3-yaml \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /workspace
+
+# Default command
+CMD ["/bin/bash"]

--- a/docker/docker-compose.debtools.yml
+++ b/docker/docker-compose.debtools.yml
@@ -1,0 +1,9 @@
+services:
+  debtools:
+    build:
+      context: .
+      dockerfile: Dockerfile.debtools
+    volumes:
+      - ../:/workspace
+    working_dir: /workspace
+    command: /bin/bash


### PR DESCRIPTION
## Problem

PR #58 introduced a permission error because it used `devtools` (development image) to build packages:
```
dh_auto_clean: error: mkdir /workspace/debian/.debhelper: Permission denied
```

**Root cause**: `Dockerfile.devtools` runs as non-root `vscode` user for VSCode Dev Container compatibility, but `dpkg-buildpackage` requires root access to write build artifacts.

## Solution

Create dedicated `Dockerfile.debtools` (like cockpit-apt) specifically for building packages.

## Changes

### Added Files

**`docker/Dockerfile.debtools`**:
- Clean Debian trixie image for building
- Runs as root (no USER directive)
- Only build dependencies (no dev tools like uv)

**`docker/docker-compose.debtools.yml`**:
- Compose file for local package building

### Updated Files

**`.github/actions/build-deb/action.yml`**:
- Cache key: `buildx-devtools` → `buildx-debtools`
- Image: `Dockerfile.devtools` → `Dockerfile.debtools`
- Tag: `devtools:latest` → `debtools:latest`

**`.github/scripts/build-deb-package.sh`**:
- Container: `devtools:latest` → `debtools:latest`
- Comments updated

## Proper Separation of Concerns

✅ **devtools**: Interactive development with VSCode (runs as `vscode` user)  
✅ **debtools**: Package building (runs as `root`)  

This pattern exactly matches **cockpit-apt** (see cockpit-apt PR #90).

## Testing

The workflow should now:
1. Build debtools image (cached)
2. Run dpkg-buildpackage as root
3. Successfully create .deb package
4. No permission errors

Fixes the build failure from PR #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)