### PR TITLE
docs: update reference to LIFE_WITH_CLAUDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cd halos-distro
 ```
 
 See `halos-distro/docs/` for development workflows:
-- `HUMAN_DEVELOPMENT_GUIDANCE.md` - Quick start guide
+- `LIFE_WITH_CLAUDE.md` - Quick start guide
 - `IMPLEMENTATION_CHECKLIST.md` - Development checklist
 - `DEVELOPMENT_WORKFLOW.md` - Detailed workflows
 


### PR DESCRIPTION
## Summary

Update workspace documentation reference in README.md to point to `LIFE_WITH_CLAUDE.md` instead of the deprecated `HUMAN_DEVELOPMENT_GUIDANCE.md`.

## Changes

- Update README.md to reference new documentation filename

## Related

- Part of halos-distro documentation reorganization
- See https://github.com/hatlabs/halos-distro/pull/24

🤖 Generated with [Claude Code](https://claude.com/claude-code)