### PR TITLE
fix(ci): attach .deb package to draft release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,8 @@ jobs:
             gh release create "v${VERSION}" \
               --draft \
               --title "v${VERSION}" \
-              --notes-file release_notes.md
+              --notes-file release_notes.md \
+              *.deb
             echo "✅ Draft release created successfully"
           fi
         env:


### PR DESCRIPTION
## Problem

When the draft release was created by the main.yml workflow, it was missing the .deb package asset. This caused an issue where:

1. ✅ Pre-release `v0.2.0` was created WITH the .deb file
2. ❌ Draft release `v0.2.0-1` was created WITHOUT the .deb file
3. When the draft was published, `release.yml` triggered `apt.hatlabs.fi` to download the package
4. No .deb file existed on the v0.2.0-1 release, so nothing was added to trixie-stable

## Root Cause

The "Create draft release" step in main.yml (line 122-125) was missing the `*.deb` parameter:

```yaml
gh release create "v${VERSION}" \
  --draft \
  --title "v${VERSION}" \
  --notes-file release_notes.md
  # ← Missing *.deb here!
```

Compare with the pre-release creation (line 94-98) which correctly includes it:

```yaml
gh release create "v${TAG_VERSION}" \
  --prerelease \
  --title "v${TAG_VERSION} (Pre-release)" \
  --notes-file release_notes.md \
  *.deb  # ← .deb file attached
```

## Solution

Add `*.deb` to the draft release creation command so the package is attached when the draft is created.

## Impact

- Fixes the issue where publishing draft releases resulted in no package in apt repository
- Ensures draft releases have the .deb package attached immediately
- Makes draft and pre-release creation behavior consistent

## Testing

After merging, the next push to main will:
1. Create pre-release with .deb ✅
2. Create draft release with .deb ✅
3. Publishing the draft will trigger apt repo update with package available ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)