### PR TITLE
fix(ci): add --repo flag to gh release view command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Verify release has assets
         run: |
           STABLE_TAG="${{ steps.version.outputs.stable_tag }}"
-          ASSET_COUNT=$(gh release view "$STABLE_TAG" --json assets --jq '.assets | length')
+          ASSET_COUNT=$(gh release view "$STABLE_TAG" --repo ${{ github.repository }} --json assets --jq '.assets | length')
 
           if [ "$ASSET_COUNT" -eq 0 ]; then
             echo "❌ Error: Release has no assets attached"


### PR DESCRIPTION
## Problem

The `dispatch-to-apt` job was failing when stable releases were published:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

See: https://github.com/hatlabs/container-packaging-tools/actions/runs/19548177756/job/55972362596

## Root Cause

The `gh release view` command requires either:
1. Being in a git repository, OR  
2. Having `--repo` flag specified

The workflow had neither, causing the failure.

## Solution

Add `--repo ${{ github.repository }}` flag to explicitly specify which repository to query. This is cleaner than adding a checkout step just for one command.

## Testing

- [ ] Verify workflow syntax is valid
- [ ] Test with next stable release

## Impact

Critical fix - blocks stable release publishing to apt.hatlabs.fi