### PR TITLE
fix(ci): add required apt-distro and apt-component inputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,5 +10,7 @@ jobs:
     with:
       package-name: container-packaging-tools
       package-description: 'Tools for generating Debian packages from container application definitions'
+      apt-distro: trixie
+      apt-component: main
     secrets:
       APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,5 +7,8 @@ on:
 jobs:
   publish:
     uses: hatlabs/shared-workflows/.github/workflows/publish-stable.yml@main
+    with:
+      apt-distro: trixie
+      apt-component: main
     secrets:
       APT_REPO_PAT: ${{ secrets.APT_REPO_PAT }}


### PR DESCRIPTION
## Summary
- Added `apt-distro: trixie` and `apt-component: main` to workflow inputs
- Required since shared-workflows made these inputs mandatory

## Test plan
- [ ] PR checks pass
- [ ] Merge to main triggers successful build

🤖 Generated with [Claude Code](https://claude.com/claude-code)