### PR TITLE
feat: improve environment file handling and paths

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -277,13 +277,17 @@ Standard Docker Compose v3.8+ format containing:
 **Usage**:
 - Copied verbatim to package (not parsed or modified)
 - Used by systemd service for container lifecycle
-- Environment variables substituted at runtime from .env file
+- Environment variables substituted at runtime from env file
 
 **Integration Points**:
 - Environment variables referenced with ${VAR:-default} syntax
-- Volumes should use bind mounts for persistence (paths under /var/lib/container-apps/<package>/)
+- Use `${CONTAINER_DATA_ROOT}` for bind mount paths (auto-set to `/var/lib/container-apps/<package>/data`)
 - Container name should be meaningful for management
 - No restart policy (systemd manages lifecycle)
+
+**System-Managed Variables**:
+The following environment variables are automatically injected into the env file:
+- `CONTAINER_DATA_ROOT`: Base path for container data storage (`/var/lib/container-apps/<package>/data`). Use this for all bind mount paths to keep container data separate from package files.
 
 ### Configuration Schema Model
 
@@ -308,7 +312,7 @@ Hierarchical configuration definition:
 **Purpose**:
 - Defines user-configurable parameters
 - Used by Cockpit UI (Phase 2) for configuration forms
-- Drives environment variable generation in .env file
+- Drives environment variable generation in env file
 
 **Field Types**:
 - string: Text input
@@ -337,11 +341,12 @@ Package changes and checksums
 /var/lib/container-apps/<package>/
 ├── docker-compose.yml
 ├── metadata.yaml
+├── config.yml
 └── .env.template
 
 /etc/container-apps/<package>/
-├── config.yml
-└── .env (created by postinst)
+├── env.defaults (updated on every install/upgrade)
+└── env (user overrides, created once on first install)
 
 /etc/systemd/system/
 └── <package>.service

--- a/src/generate_container_packages/template_context.py
+++ b/src/generate_container_packages/template_context.py
@@ -87,7 +87,8 @@ def _build_service_context(
         "name": f"{package_name}.service",
         "description": f"{metadata['name']} Container",
         "working_directory": f"/var/lib/container-apps/{package_name}",
-        "env_file": f"/etc/container-apps/{package_name}/.env",
+        "env_defaults_file": f"/etc/container-apps/{package_name}/env.defaults",
+        "env_file": f"/etc/container-apps/{package_name}/env",
     }
 
 

--- a/templates/debian/postinst.j2
+++ b/templates/debian/postinst.j2
@@ -6,9 +6,12 @@ case "$1" in
         # Create configuration directory if it doesn't exist
         mkdir -p "{{ paths.etc }}"
 
-        # Generate .env from template if it doesn't exist
-        if [ ! -f "{{ paths.etc }}/.env" ]; then
-            cp "{{ paths.lib }}/.env.template" "{{ paths.etc }}/.env"
+        # Always update env.defaults from template (contains system defaults)
+        cp "{{ paths.lib }}/.env.template" "{{ paths.etc }}/env.defaults"
+
+        # Create env for user overrides if it doesn't exist (with commented defaults)
+        if [ ! -f "{{ paths.etc }}/env" ]; then
+            cp "{{ paths.lib }}/.env.user-template" "{{ paths.etc }}/env"
         fi
 
         # Only interact with systemd if it's running (not in containers or minimal envs)

--- a/templates/debian/rules.j2
+++ b/templates/debian/rules.j2
@@ -12,12 +12,12 @@ override_dh_auto_install:
 		debian/{{ package.name }}/{{ paths.lib }}/docker-compose.yml
 	install -D -m 644 metadata.yaml \
 		debian/{{ package.name }}/{{ paths.lib }}/metadata.yaml
+	install -D -m 644 config.yml \
+		debian/{{ package.name }}/{{ paths.lib }}/config.yml
 	install -D -m 644 .env.template \
 		debian/{{ package.name }}/{{ paths.lib }}/.env.template
-
-	# Install configuration schema to /etc/container-apps/
-	install -D -m 644 config.yml \
-		debian/{{ package.name }}/{{ paths.etc }}/config.yml
+	install -D -m 644 .env.user-template \
+		debian/{{ package.name }}/{{ paths.lib }}/.env.user-template
 
 {% if has_icon %}
 	# Install icon

--- a/templates/systemd/service.j2
+++ b/templates/systemd/service.j2
@@ -7,6 +7,7 @@ Requires=docker.service
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory={{ service.working_directory }}
+EnvironmentFile=-{{ service.env_defaults_file }}
 EnvironmentFile=-{{ service.env_file }}
 ExecStart=/bin/sh -c 'if command -v docker-compose >/dev/null 2>&1; then docker-compose up -d; else docker compose up -d; fi'
 ExecStop=/bin/sh -c 'if command -v docker-compose >/dev/null 2>&1; then docker-compose down; else docker compose down; fi'

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -30,50 +30,79 @@ class TestGenerateEnvTemplate:
     def test_empty_config(self, tmp_path):
         """Test generating .env.template with empty config."""
         app_def = mock.Mock(spec=AppDefinition)
-        app_def.metadata = {}
+        app_def.metadata = {"package_name": "test-app-container"}
 
         generate_env_template(app_def, tmp_path)
 
+        # Check .env.template (for env.defaults)
         env_file = tmp_path / ".env.template"
         assert env_file.exists()
         content = env_file.read_text()
-        assert "No default configuration" in content
+        # Should still have CONTAINER_DATA_ROOT even with no default_config
+        assert 'CONTAINER_DATA_ROOT="/var/lib/container-apps/test-app-container/data"' in content
+        assert "System-managed variables" in content
+
+        # Check .env.user-template (for env)
+        user_file = tmp_path / ".env.user-template"
+        assert user_file.exists()
+        user_content = user_file.read_text()
+        assert "User environment overrides" in user_content
+        # No app config means no commented values
+        assert "CONTAINER_DATA_ROOT" not in user_content
 
     def test_simple_config(self, tmp_path):
         """Test generating .env.template with simple config."""
         app_def = mock.Mock(spec=AppDefinition)
         app_def.metadata = {
+            "package_name": "test-app-container",
             "default_config": {
                 "KEY1": "value1",
                 "KEY2": "value2",
-            }
+            },
         }
 
         generate_env_template(app_def, tmp_path)
 
+        # Check .env.template (for env.defaults)
         env_file = tmp_path / ".env.template"
         assert env_file.exists()
         content = env_file.read_text()
+        # Check system-managed variable
+        assert 'CONTAINER_DATA_ROOT="/var/lib/container-apps/test-app-container/data"' in content
+        # Check application config
         assert 'KEY1="value1"' in content
         assert 'KEY2="value2"' in content
+        assert "Application configuration" in content
+
+        # Check .env.user-template (for env) - commented defaults
+        user_file = tmp_path / ".env.user-template"
+        assert user_file.exists()
+        user_content = user_file.read_text()
+        assert '#KEY1="value1"' in user_content
+        assert '#KEY2="value2"' in user_content
+        # Should NOT have system variables
+        assert "CONTAINER_DATA_ROOT" not in user_content
 
     def test_config_with_special_characters(self, tmp_path):
         """Test env template generation with special characters."""
         app_def = mock.Mock(spec=AppDefinition)
         app_def.metadata = {
+            "package_name": "test-app-container",
             "default_config": {
                 "PASSWORD": 'test"password',
                 "PATH": "/usr/bin:$HOME/bin",
                 "COMMAND": "echo `whoami`",
                 "BACKSLASH": "\\path\\to\\file",
                 "NEWLINE": "line1\\nline2",
-            }
+            },
         }
 
         generate_env_template(app_def, tmp_path)
 
         env_file = tmp_path / ".env.template"
         content = env_file.read_text()
+        # Check system-managed variable is present
+        assert 'CONTAINER_DATA_ROOT="/var/lib/container-apps/test-app-container/data"' in content
         # Check escaping
         assert 'PASSWORD="test\\"password"' in content
         assert "$$HOME" in content

--- a/tests/test_package_install.py
+++ b/tests/test_package_install.py
@@ -141,7 +141,8 @@ class TestPackageInstallation:
         # Check configuration files
         config_dir = Path("/etc/container-apps/simple-test-app-container")
         assert config_dir.exists()
-        assert (config_dir / ".env").exists()
+        assert (config_dir / "env.defaults").exists()
+        assert (config_dir / "env").exists()
 
         # Check systemd service
         service_file = Path("/etc/systemd/system/simple-test-app-container.service")

--- a/tests/test_template_context.py
+++ b/tests/test_template_context.py
@@ -56,8 +56,12 @@ class TestBuildContext:
             == "/var/lib/container-apps/test-app-container"
         )
         assert (
+            context["service"]["env_defaults_file"]
+            == "/etc/container-apps/test-app-container/env.defaults"
+        )
+        assert (
             context["service"]["env_file"]
-            == "/etc/container-apps/test-app-container/.env"
+            == "/etc/container-apps/test-app-container/env"
         )
 
         # Verify paths


### PR DESCRIPTION
## Summary

- Auto-inject `CONTAINER_DATA_ROOT` environment variable pointing to `/var/lib/container-apps/{package}/data` to protect package files from accidental bind mount overwrites
- Rename `.env` to `env` in `/etc/container-apps/{package}/` (avoid hidden config files in /etc)
- Move `config.yml` from `/etc/` to `/var/lib/` (it's schema metadata, not user configuration)
- Add layered environment files:
  - `env.defaults` - system defaults, updated on every install/upgrade
  - `env` - user overrides, created once on first install, never overwritten
- Pre-populate `env` with commented defaults so users can see available options

## Directory structure after changes

```
/var/lib/container-apps/{package}/
├── docker-compose.yml
├── metadata.yaml
├── config.yml              # Configuration schema (moved from /etc)
├── .env.template           # Full defaults (-> env.defaults)
└── .env.user-template      # Commented defaults (-> env)

/etc/container-apps/{package}/
├── env.defaults            # Updated on every upgrade
└── env                     # User overrides (never overwritten)
```

## Test plan

- [x] All unit tests pass
- [x] Linter passes
- [x] Type checker passes
- [ ] Integration test with actual package build

🤖 Generated with [Claude Code](https://claude.com/claude-code)