### PR TITLE
refactor: rename .env.template to env.template

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -176,7 +176,7 @@ The Loader produces a unified data structure containing:
 - debian/package-name.service: Service unit file
 
 **Application Files**:
-- .env.template: Environment variable defaults
+- env.template: Environment variable defaults
 
 **Template Context Structure**:
 The context passed to templates includes:
@@ -342,7 +342,7 @@ Package changes and checksums
 ├── docker-compose.yml
 ├── metadata.yaml
 ├── config.yml
-└── .env.template
+└── env.template
 
 /etc/container-apps/<package>/
 ├── env.defaults (updated on every install/upgrade)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -284,7 +284,7 @@ output-directory/
 │   ├── config.yml               # Copied from input
 │   ├── metadata.yaml            # Copied from input
 │   ├── icon.(svg|png)           # Copied from input (if present)
-│   └── .env.template            # Generated from default_config
+│   └── env.template            # Generated from default_config
 └── <package-name>_<version>_<arch>.deb  # Built package (after dpkg-buildpackage)
 ```
 
@@ -324,8 +324,8 @@ override_dh_auto_install:
 		debian/<package>/var/lib/container-apps/<package>/metadata.yaml
 	install -D -m 644 config.yml \
 		debian/<package>/var/lib/container-apps/<package>/config.yml
-	install -D -m 644 .env.template \
-		debian/<package>/var/lib/container-apps/<package>/.env.template
+	install -D -m 644 env.template \
+		debian/<package>/var/lib/container-apps/<package>/env.template
 
 	# Install icon if present (SVG or PNG)
 	if [ -f icon.svg ]; then \
@@ -350,7 +350,7 @@ set -e
 case "$1" in
     configure)
         # Always update env.defaults from template (contains system defaults)
-        cp /var/lib/container-apps/<package>/.env.template \
+        cp /var/lib/container-apps/<package>/env.template \
            /etc/container-apps/<package>/env.defaults
 
         # Create empty env for user overrides if it doesn't exist
@@ -529,7 +529,7 @@ All generated packages follow these standard paths:
 - `docker-compose.yml` - Docker Compose configuration
 - `metadata.yaml` - Application metadata (for UI consumption)
 - `config.yml` - Configuration schema (field definitions for UI)
-- `.env.template` - Environment variable template
+- `env.template` - Environment variable template
 
 ### Configuration Directory
 **Path**: `/etc/container-apps/<package-name>/`

--- a/src/generate_container_packages/builder.py
+++ b/src/generate_container_packages/builder.py
@@ -133,25 +133,25 @@ def copy_source_files(app_def: AppDefinition, source_dir: Path) -> None:
             dst = source_dir / screenshot_path.name
             shutil.copy2(screenshot_path, dst)
 
-    # Generate .env.template from default_config
+    # Generate env.template from default_config
     generate_env_template(app_def, source_dir)
 
 
 def generate_env_template(app_def: AppDefinition, source_dir: Path) -> None:
-    """Generate .env.template and .env.user-template files from default configuration.
+    """Generate env.template and env.user-template files from default configuration.
 
     Args:
         app_def: Application definition
         source_dir: Destination directory
 
     Generates two files:
-    - .env.template: Full defaults including system variables (-> env.defaults)
-    - .env.user-template: App defaults as comments for user reference (-> env)
+    - env.template: Full defaults including system variables (-> env.defaults)
+    - env.user-template: App defaults as comments for user reference (-> env)
     """
     package_name = app_def.metadata["package_name"]
     default_config = app_def.metadata.get("default_config", {})
 
-    # Generate .env.template (full defaults for env.defaults)
+    # Generate env.template (full defaults for env.defaults)
     lines = [
         "# System-managed variables (do not modify)\n",
         f'CONTAINER_DATA_ROOT="/var/lib/container-apps/{package_name}/data"\n',
@@ -177,10 +177,10 @@ def generate_env_template(app_def: AppDefinition, source_dir: Path) -> None:
         escaped_config[key] = value_str
         lines.append(f'{key}="{value_str}"\n')
 
-    env_template = source_dir / ".env.template"
+    env_template = source_dir / "env.template"
     env_template.write_text("".join(lines), encoding="utf-8")
 
-    # Generate .env.user-template (commented defaults for user env file)
+    # Generate env.user-template (commented defaults for user env file)
     user_lines = [
         "# User environment overrides\n",
         "# Uncomment and modify values to override defaults from env.defaults\n",
@@ -190,7 +190,7 @@ def generate_env_template(app_def: AppDefinition, source_dir: Path) -> None:
     for key, value_str in escaped_config.items():
         user_lines.append(f'#{key}="{value_str}"\n')
 
-    env_user_template = source_dir / ".env.user-template"
+    env_user_template = source_dir / "env.user-template"
     env_user_template.write_text("".join(user_lines), encoding="utf-8")
 
 

--- a/templates/debian/postinst.j2
+++ b/templates/debian/postinst.j2
@@ -7,11 +7,11 @@ case "$1" in
         mkdir -p "{{ paths.etc }}"
 
         # Always update env.defaults from template (contains system defaults)
-        cp "{{ paths.lib }}/.env.template" "{{ paths.etc }}/env.defaults"
+        cp "{{ paths.lib }}/env.template" "{{ paths.etc }}/env.defaults"
 
         # Create env for user overrides if it doesn't exist (with commented defaults)
         if [ ! -f "{{ paths.etc }}/env" ]; then
-            cp "{{ paths.lib }}/.env.user-template" "{{ paths.etc }}/env"
+            cp "{{ paths.lib }}/env.user-template" "{{ paths.etc }}/env"
         fi
 
         # Only interact with systemd if it's running (not in containers or minimal envs)

--- a/templates/debian/rules.j2
+++ b/templates/debian/rules.j2
@@ -14,10 +14,10 @@ override_dh_auto_install:
 		debian/{{ package.name }}/{{ paths.lib }}/metadata.yaml
 	install -D -m 644 config.yml \
 		debian/{{ package.name }}/{{ paths.lib }}/config.yml
-	install -D -m 644 .env.template \
-		debian/{{ package.name }}/{{ paths.lib }}/.env.template
-	install -D -m 644 .env.user-template \
-		debian/{{ package.name }}/{{ paths.lib }}/.env.user-template
+	install -D -m 644 env.template \
+		debian/{{ package.name }}/{{ paths.lib }}/env.template
+	install -D -m 644 env.user-template \
+		debian/{{ package.name }}/{{ paths.lib }}/env.user-template
 
 {% if has_icon %}
 	# Install icon

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -28,22 +28,22 @@ class TestGenerateEnvTemplate:
     """Tests for generate_env_template function."""
 
     def test_empty_config(self, tmp_path):
-        """Test generating .env.template with empty config."""
+        """Test generating env.template with empty config."""
         app_def = mock.Mock(spec=AppDefinition)
         app_def.metadata = {"package_name": "test-app-container"}
 
         generate_env_template(app_def, tmp_path)
 
-        # Check .env.template (for env.defaults)
-        env_file = tmp_path / ".env.template"
+        # Check env.template (for env.defaults)
+        env_file = tmp_path / "env.template"
         assert env_file.exists()
         content = env_file.read_text()
         # Should still have CONTAINER_DATA_ROOT even with no default_config
         assert 'CONTAINER_DATA_ROOT="/var/lib/container-apps/test-app-container/data"' in content
         assert "System-managed variables" in content
 
-        # Check .env.user-template (for env)
-        user_file = tmp_path / ".env.user-template"
+        # Check env.user-template (for env)
+        user_file = tmp_path / "env.user-template"
         assert user_file.exists()
         user_content = user_file.read_text()
         assert "User environment overrides" in user_content
@@ -51,7 +51,7 @@ class TestGenerateEnvTemplate:
         assert "CONTAINER_DATA_ROOT" not in user_content
 
     def test_simple_config(self, tmp_path):
-        """Test generating .env.template with simple config."""
+        """Test generating env.template with simple config."""
         app_def = mock.Mock(spec=AppDefinition)
         app_def.metadata = {
             "package_name": "test-app-container",
@@ -63,8 +63,8 @@ class TestGenerateEnvTemplate:
 
         generate_env_template(app_def, tmp_path)
 
-        # Check .env.template (for env.defaults)
-        env_file = tmp_path / ".env.template"
+        # Check env.template (for env.defaults)
+        env_file = tmp_path / "env.template"
         assert env_file.exists()
         content = env_file.read_text()
         # Check system-managed variable
@@ -74,8 +74,8 @@ class TestGenerateEnvTemplate:
         assert 'KEY2="value2"' in content
         assert "Application configuration" in content
 
-        # Check .env.user-template (for env) - commented defaults
-        user_file = tmp_path / ".env.user-template"
+        # Check env.user-template (for env) - commented defaults
+        user_file = tmp_path / "env.user-template"
         assert user_file.exists()
         user_content = user_file.read_text()
         assert '#KEY1="value1"' in user_content
@@ -99,7 +99,7 @@ class TestGenerateEnvTemplate:
 
         generate_env_template(app_def, tmp_path)
 
-        env_file = tmp_path / ".env.template"
+        env_file = tmp_path / "env.template"
         content = env_file.read_text()
         # Check system-managed variable is present
         assert 'CONTAINER_DATA_ROOT="/var/lib/container-apps/test-app-container/data"' in content
@@ -124,7 +124,7 @@ class TestCopySourceFiles:
         assert (dest_dir / "metadata.yaml").exists()
         assert (dest_dir / "docker-compose.yml").exists()
         assert (dest_dir / "config.yml").exists()
-        assert (dest_dir / ".env.template").exists()
+        assert (dest_dir / "env.template").exists()
 
     def test_copy_with_icon(self, tmp_path):
         """Test copying with icon file."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -158,7 +158,7 @@ class TestPipelineBuildPreparation:
 
         # Verify source files copied
         assert (build_dir / "docker-compose.yml").exists()
-        assert (build_dir / ".env.template").exists()
+        assert (build_dir / "env.template").exists()
 
         # Verify debian/ directory copied
         debian_dir = build_dir / "debian"


### PR DESCRIPTION
## Summary

Remove leading dot from template files for consistency with other non-hidden config files. Hidden files are difficult to find.

**Changes:**
- `.env.template` → `env.template`
- `.env.user-template` → `env.user-template`

## Test plan

- [x] All unit tests pass
- [x] Linter passes
- [x] Type checker passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)