### PR TITLE
feat(systemd): run containers in foreground mode

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -501,12 +501,14 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
 WorkingDirectory={{ service.working_directory }}
-EnvironmentFile={{ service.env_file }}
-ExecStart=/usr/bin/docker-compose up -d
-ExecStop=/usr/bin/docker-compose down
+EnvironmentFile=-{{ service.env_defaults_file }}
+EnvironmentFile=-{{ service.env_file }}
+ExecStart=/bin/sh -c 'docker compose up'
+ExecStop=/bin/sh -c 'docker compose down'
+Restart=on-failure
+RestartSec=10
 StandardOutput=journal
 StandardError=journal
 
@@ -514,7 +516,7 @@ StandardError=journal
 WantedBy=multi-user.target
 ```
 
-**Note**: Type=oneshot with RemainAfterExit=yes ensures systemd tracks the service state. The restart policy is handled by systemd (automatic restart on failure), not by Docker Compose.
+**Note**: Type=simple runs docker-compose in foreground mode, allowing systemd to properly manage the container lifecycle. Container logs are streamed to journal via stdout/stderr. Restart=on-failure provides automatic recovery.
 
 ## Path Conventions
 

--- a/templates/systemd/service.j2
+++ b/templates/systemd/service.j2
@@ -4,13 +4,14 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
 WorkingDirectory={{ service.working_directory }}
 EnvironmentFile=-{{ service.env_defaults_file }}
 EnvironmentFile=-{{ service.env_file }}
-ExecStart=/bin/sh -c 'if command -v docker-compose >/dev/null 2>&1; then docker-compose up -d; else docker compose up -d; fi'
+ExecStart=/bin/sh -c 'if command -v docker-compose >/dev/null 2>&1; then docker-compose up; else docker compose up; fi'
 ExecStop=/bin/sh -c 'if command -v docker-compose >/dev/null 2>&1; then docker-compose down; else docker compose down; fi'
+Restart=on-failure
+RestartSec=10
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Summary

- Change from `Type=oneshot` + detached mode to `Type=simple` + foreground mode
- Run `docker compose up` without `-d` flag
- Add `Restart=on-failure` with 10 second delay for automatic recovery
- Remove `RemainAfterExit` (not needed for simple type)

## Problem

Previously, containers ran in detached mode:
- `systemctl status` showed "exited" even when container was running
- Logs went to Docker, not journal directly
- Service state didn't reflect actual container state

## Solution

Run containers in foreground mode:
- Systemd properly manages container lifecycle
- `systemctl status` shows actual running state
- `journalctl -u <service>` shows container logs
- Automatic restart on failure

## Test plan

- [x] All unit tests pass
- [ ] CI builds pass
- [ ] Test on actual device:
  - [ ] `systemctl start <container>` starts container in foreground
  - [ ] `systemctl status <container>` shows "active (running)"
  - [ ] `journalctl -u <container>` shows container logs
  - [ ] Container restarts automatically on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)