### PR TITLE
docs: reorganize specifications and add CasaOS converter planning

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,868 +1,154 @@
 # Container Packaging Tools - System Architecture
 
-**Status**: Draft
 **Version**: 1.0
-**Date**: 2025-11-11
-**Last Updated**: 2025-11-11
+**Date**: 2025-11-26
+**Status**: Active
 
-## Document Purpose
+## Overview
 
-This document describes the system architecture of the Container Packaging Tools project. It details the components, their relationships, data models, technology decisions, and deployment considerations.
+This document serves as the index to all architecture documentation for the Container Packaging Tools project. The system consists of multiple components with distinct responsibilities, each documented in its own architecture specification.
 
-## System Overview
+## System Purpose
 
-### Architectural Style
+Container Packaging Tools automates the creation of Debian packages for containerized applications. The system transforms declarative application definitions into Debian packages with proper systemd integration, validation, and lifecycle management.
 
-Container Packaging Tools follows a **pipeline architecture** pattern where input data flows through a series of processing stages to produce output artifacts. The system is designed as a single-process command-line application with no external dependencies or network communication.
+## Architectural Components
 
-### High-Level Architecture
+The system is organized into two main functional subsystems:
+
+### 1. Core Package Generation System
+
+The core system handles conversion of application definitions to Debian packages through template rendering, validation, and package building.
+
+**📐 [Package Generation Architecture](PACKAGING_ARCHITECTURE.md)**
+
+This architecture covers:
+- Component structure (CLI, validator, loader, renderer, builder)
+- Data flow through the packaging pipeline
+- Template system design
+- Pydantic schema models
+- Debian package structure
+- systemd service generation
+- Build process and tooling
+
+### 2. CasaOS Converter System
+
+The converter system transforms CasaOS application definitions into HaLOS format, handling parsing, transformation, and asset management.
+
+**📐 [CasaOS Converter Architecture](CONVERTER_ARCHITECTURE.md)**
+
+This architecture covers:
+- Converter component structure (parser, transformer, asset manager, generator)
+- Integration with core packaging system
+- CasaOS format parsing and validation
+- Metadata transformation pipeline
+- Asset downloading and caching
+- Batch processing and update detection
+- Configuration mapping system
+
+## System Integration
+
+The two subsystems work together in a pipeline:
 
 ```
-Input Directory          Tool Pipeline              Output Directory
-┌──────────────┐        ┌─────────────┐            ┌──────────────┐
-│ metadata.yaml│───────>│  Validator  │            │              │
-│ compose.yml  │        └──────┬──────┘            │              │
-│ config.yml   │               │                   │              │
-│ (optional)   │        ┌──────▼──────┐            │              │
-│ icon.svg/png │───────>│   Loader    │            │              │
-│ screenshots  │        └──────┬──────┘            │              │
-└──────────────┘               │                   │              │
-                        ┌──────▼──────┐            │              │
-                        │  Template   │            │              │
-                        │  Renderer   │            │              │
-                        └──────┬──────┘            │              │
-                               │                   │              │
-                        ┌──────▼──────┐            │              │
-                        │  Package    │            │  .deb file   │
-                        │  Builder    │───────────>│  .buildinfo  │
-                        └─────────────┘            │  .changes    │
-                                                   └──────────────┘
+CasaOS Apps → [Converter] → HaLOS Format → [Core Packager] → Debian Packages
 ```
 
-## Core Components
-
-### 1. Command-Line Interface (CLI)
-
-**Purpose**: Parse command-line arguments and orchestrate the pipeline
-
-**Responsibilities**:
-- Parse and validate command-line arguments
-- Set up logging and verbosity levels
-- Initialize other components with configuration
-- Handle top-level exceptions and exit codes
-- Display progress and status messages
-
-**Key Design Decisions**:
-- Uses Python argparse for standard Unix-style CLI
-- Supports both positional (input directory) and optional arguments
-- Exit codes indicate specific error categories for scripting
-- Help text generated automatically from argument definitions
-
-**Interactions**:
-- Calls Validator with input directory path
-- Calls Loader to read and parse input files
-- Calls Template Renderer with loaded data
-- Calls Package Builder with rendered files
-- Reports errors and success messages to user
-
-### 2. Input Validator
-
-**Purpose**: Validate all input files before processing
-
-**Responsibilities**:
-- Check required files exist (metadata.yaml, docker-compose.yml, config.yml)
-- Validate JSON and YAML syntax
-- Validate using Pydantic models
-- Perform cross-file consistency checks
-- Collect and format validation errors
-
-**Key Design Decisions**:
-- Fails fast on first validation error (or collects all errors with --strict)
-- Uses Pydantic models for type-safe validation with Python type hints
-- Custom validators for cross-file checks
-- Clear error messages with file paths and line numbers
-
-**Validation Stages**:
-
-**Stage 1 - File Presence**:
-- Verify required files exist
-- Check optional file paths if referenced in metadata
-- Validate file permissions (readable)
-
-**Stage 2 - Syntax Validation**:
-- Parse JSON files with error recovery
-- Parse YAML files with error recovery
-- Check Docker Compose schema version
-
-**Stage 3 - Schema Validation**:
-- Validate metadata.yaml using Pydantic model
-- Validate config.yml using Pydantic model
-- Check required fields present
-- Validate format constraints (names, versions, emails)
-
-**Stage 4 - Cross-Validation**:
-- Verify package name ends with `-container`
-- Check tags include `role::container-app`
-- Ensure config field IDs match environment variables
-- Validate referenced files exist (icons, screenshots)
-
-**Interactions**:
-- Reads schema files from installed schemas directory
-- Returns validation results to CLI
-- Provides detailed error context for user feedback
-
-### 3. File Loader
-
-**Purpose**: Load and parse validated input files
-
-**Responsibilities**:
-- Load and parse YAML files (metadata, compose, config)
-- Copy binary files (icons, screenshots)
-- Build internal data model
-- Handle file encoding issues
-
-**Key Design Decisions**:
-- Assumes files are valid (validation already passed)
-- Loads all data into memory (files are small)
-- Preserves original YAML structure for templates
-- Uses UTF-8 encoding for all text files
-
-**Data Model**:
-The Loader produces a unified data structure containing:
-- Parsed metadata (Python dict from YAML)
-- Docker Compose configuration (Python dict from YAML)
-- Configuration schema (Python dict from YAML)
-- File paths to binary assets
-- Computed values (timestamps, tool version)
-
-**Interactions**:
-- Reads files from input directory
-- Passes data model to Template Renderer
-- Reports file loading errors to CLI
-
-### 4. Template Renderer
-
-**Purpose**: Generate package files from templates and metadata
-
-**Responsibilities**:
-- Load Jinja2 templates from installed location
-- Create template context from data model
-- Render each template file
-- Format multi-line text for Debian control files
-- Handle optional template sections
-
-**Key Design Decisions**:
-- Uses Jinja2 for powerful, maintainable templates
-- Templates are separate from code for easy customization
-- All template data passed as context dictionary
-- Templates handle missing optional fields gracefully
-
-**Template Types**:
-
-**Debian Control Files**:
-- debian/control: Package metadata and dependencies
-- debian/rules: Build rules (mostly static)
-- debian/install: File installation mappings
-- debian/compat: Debhelper compatibility (static)
-- debian/copyright: License and copyright info
-- debian/changelog: Package changelog
-
-**Maintainer Scripts**:
-- debian/postinst: Post-installation (service setup)
-- debian/prerm: Pre-removal (service stop)
-- debian/postrm: Post-removal (cleanup)
-
-**systemd Integration**:
-- debian/package-name.service: Service unit file
-
-**Application Files**:
-- env.template: Environment variable defaults
-
-**Template Context Structure**:
-The context passed to templates includes:
-- package: All package metadata (name, version, description, etc.)
-- service: systemd service configuration
-- paths: Standard installation paths
-- web_ui: Web interface configuration
-- default_config: Default environment variables
-- timestamp: Build timestamp
-- tool_version: Tool version for tracking
-
-**Interactions**:
-- Loads templates from `/usr/share/container-packaging-tools/templates/`
-- Receives data model from Loader
-- Writes rendered files to build directory
-- Reports rendering errors to CLI
-
-### 5. Package Builder
-
-**Purpose**: Build Debian package using dpkg-buildpackage
-
-**Responsibilities**:
-- Create build directory structure
-- Copy source files to build directory
-- Copy rendered templates to debian/ subdirectory
-- Invoke dpkg-buildpackage with appropriate flags
-- Move generated packages to output directory
-- Clean up temporary build artifacts
-
-**Key Design Decisions**:
-- Uses standard Debian tools (no custom package building)
-- Generates binary-only unsigned packages by default
-- Preserves build directory on failure for debugging
-- Captures build output for error reporting
-
-**Build Process Flow**:
-
-**Step 1 - Preparation**:
-- Create temporary build directory
-- Create debian/ subdirectory
-- Copy input files (metadata, compose, config, icons)
-
-**Step 2 - File Installation**:
-- Write rendered templates to debian/
-- Set executable permissions on debian/rules
-- Set executable permissions on maintainer scripts
-
-**Step 3 - Package Building**:
-- Execute dpkg-buildpackage with flags: -b -us -uc
-- Capture stdout and stderr
-- Monitor exit code
-
-**Step 4 - Artifact Collection**:
-- Move .deb file to output directory
-- Move .buildinfo and .changes files to output directory
-- Preserve or clean build directory based on flags
-
-**Interactions**:
-- Receives rendered files from Template Renderer
-- Invokes system dpkg-buildpackage command
-- Reports build progress and errors to CLI
-- Returns package file paths on success
-
-## Data Models
-
-### Metadata Model
-
-**Source**: metadata.yaml
-
-**Structure**:
-The metadata model contains all package-level information:
-- Identity: name, package_name, version, upstream_version
-- Description: description, long_description, homepage
-- Maintenance: maintainer, license
-- Classification: tags, debian_section, architecture
-- Dependencies: depends, recommends, suggests
-- Web UI: enabled, path, port, protocol
-- Configuration: default_config (environment variables)
-- Assets: icon, screenshots
-
-**Validation Rules**:
-- Package name must match pattern: lowercase, hyphens, must end with `-container`
-- Version must be valid Debian version (semver, date-based, CalVer, or hybrid)
-- Maintainer must match pattern: `Name <email@domain>`
-- Tags must include `role::container-app`
-- All fields must conform to JSON schema
-
-### Docker Compose Model
-
-**Source**: docker-compose.yml
-
-**Structure**:
-Standard Docker Compose v3.8+ format containing:
-- Services: Container definitions with images, ports, volumes, environment
-- Volumes: Bind mounts for persistent data (not named volumes)
-- Networks: Custom networks (optional)
-
-**Usage**:
-- Copied verbatim to package (not parsed or modified)
-- Used by systemd service for container lifecycle
-- Environment variables substituted at runtime from env file
-
-**Integration Points**:
-- Environment variables referenced with ${VAR:-default} syntax
-- Use `${CONTAINER_DATA_ROOT}` for bind mount paths (auto-set to `/var/lib/container-apps/<package>/data`)
-- Container name should be meaningful for management
-- No restart policy (systemd manages lifecycle)
-
-**System-Managed Variables**:
-The following environment variables are automatically injected into the env file:
-- `CONTAINER_DATA_ROOT`: Base path for container data storage (`/var/lib/container-apps/<package>/data`). Use this for all bind mount paths to keep container data separate from package files.
-
-### Configuration Schema Model
-
-**Source**: config.yml
-
-**Structure**:
-Hierarchical configuration definition:
-- Version: Schema version (currently "1.0")
-- Groups: Array of field groups
-  - Group ID: Identifier (lowercase_snake_case)
-  - Group Label: Display name
-  - Group Description: Help text (optional)
-  - Fields: Array of field definitions
-    - Field ID: Environment variable name (UPPER_SNAKE_CASE)
-    - Field Label: Display name
-    - Field Type: Data type (string, integer, boolean, enum, path, password)
-    - Default: Default value
-    - Required: Whether field is required
-    - Constraints: min, max, options (type-dependent)
-    - Description: Help text
-
-**Purpose**:
-- Defines user-configurable parameters
-- Used by Cockpit UI (Phase 2) for configuration forms
-- Drives environment variable generation in env file
-
-**Field Types**:
-- string: Text input
-- integer: Numeric input with optional min/max
-- boolean: Checkbox or toggle
-- enum: Select from predefined options
-- path: File or directory path
-- password: Masked text input
-
-### Package Output Model
-
-**Generated Artifacts**:
-The tool produces three primary artifacts:
-
-**1. Debian Binary Package (.deb)**:
-Contains all installed files with metadata
-
-**2. Build Info File (.buildinfo)**:
-Build environment information for reproducibility
-
-**3. Changes File (.changes)**:
-Package changes and checksums
-
-**Package Contents Structure**:
-```
-/var/lib/container-apps/<package>/
-├── docker-compose.yml
-├── metadata.yaml
-├── config.yml
-└── env.template
-
-/etc/container-apps/<package>/
-├── env.defaults (updated on every install/upgrade)
-└── env (user overrides, created once on first install)
-
-/etc/systemd/system/
-└── <package>.service
-
-/usr/share/pixmaps/
-└── <package>.(svg|png) (if icon provided)
-
-/usr/share/metainfo/
-└── <package>.metainfo.xml (AppStream metadata)
-
-/usr/share/doc/<package>/
-├── copyright
-└── changelog.gz
-```
+The converter produces output (metadata.yaml, config.yml, docker-compose.yml) that serves as input to the core packaging system. This modular design allows:
+
+- Independent development and testing of components
+- Support for additional input formats in the future
+- Reuse of core packaging logic across different sources
 
 ## Technology Stack
 
-### Core Technologies
-
-**Python 3.9+**:
-- **Why**: Wide availability on target platforms, excellent library ecosystem
-- **Alternatives considered**: Bash (too complex), Go (packaging overhead), Rust (fewer dependencies available)
-- **Trade-offs**: Slower than compiled languages but sufficient for tool's use case
-
-**Jinja2**:
-- **Why**: Powerful, mature template engine with good error handling
-- **Alternatives considered**: String formatting (too limited), mako (less widely used)
-- **Trade-offs**: Dependency on external library but worth it for maintainability
+**Language**: Python 3.11+ (Debian Trixie baseline)
 
-**Pydantic v2**:
-- **Why**: Type-safe validation using Python type hints, excellent error messages, fast (Rust-based core)
-- **Alternatives considered**: jsonschema (more verbose), custom validation (more code)
-- **Trade-offs**: None - Pydantic v2 is superior and available in Debian Trixie
-- **Benefits**: Can generate JSON schemas for documentation, validates parsed YAML directly
+**Core Libraries**:
+- PyYAML: YAML parsing and generation
+- Pydantic v2: Schema validation and data modeling
+- Jinja2: Template rendering
+- requests: HTTP operations (converter)
 
-**dpkg-buildpackage**:
-- **Why**: Standard Debian package building tool, handles complexity correctly
-- **Alternatives considered**: Custom package building (fragile), fpm (not standard)
-- **Trade-offs**: Requires full dpkg-dev toolchain but ensures correct packages
-
-### Python Libraries
-
-**Standard Library**:
-- argparse: CLI argument parsing
-- json: JSON parsing
-- pathlib: Path manipulation
-- subprocess: External command execution
-- logging: Structured logging
-- typing: Type hints for clarity
-
-**External Dependencies** (all in Debian Trixie):
-- python3-jinja2: Template rendering
-- python3-pydantic: Data validation with type hints
-- python3-yaml: YAML parsing
-
-### Development Tools
-
-**Package Management**:
-- uv: Fast Python package installer and resolver (replaces pip/pip-tools)
-
-**Testing**:
-- pytest: Test framework
-- pytest-cov: Coverage reporting
-
-**Code Quality**:
-- ruff: Fast Python linter and formatter (replaces flake8 and black)
-- ty: Fast Rust-based Python type checker (similar to mypy)
-- typos: Spell checker for code
-
-### Build Tools
-
-**Debian Packaging**:
-- dpkg-dev: Package building utilities
-- debhelper: Packaging helper scripts
-- lintian: Package quality checks
-
-## Integration Points
-
-### Input Integration
-
-**File System**:
-- Reads input files from specified directory
-- No network access required
-- Works offline
-
-**Validation**:
-- Self-contained validation using embedded schemas
-- No external validators or services
-
-### Output Integration
-
-**Package Repository**:
-- Generated packages compatible with any Debian APT repository
-- Can be uploaded to apt.hatlabs.fi or other repos
-- Signing happens externally (not tool's responsibility)
-
-**CI/CD Pipeline**:
-- Returns appropriate exit codes for automation
-- Structured output for parsing (with --json flag in future)
-- Reproducible builds (same input → same output)
-
-**Version Control**:
-- Input definitions stored in git repositories
-- Tool output (.deb files) typically not committed
-- Build artifacts generated on-demand or in CI
-
-### Runtime Integration
-
-**systemd**:
-- Generated service files integrate with systemd
-- Services depend on docker.service
-- Logging integrates with journald
-
-**Docker**:
-- Uses docker-compose command for container management
-- Assumes Docker installed on target system
-- No direct Docker API usage
-
-**APT Package Manager**:
-- Generated packages install via apt/dpkg
-- Dependencies resolved automatically
-- Configuration managed via debconf (future)
-
-## Deployment Architecture
-
-### Tool Distribution
-
-**Package Name**: container-packaging-tools
-
-**Installation**:
-```
-/usr/bin/
-└── generate-container-packages
-
-/usr/share/container-packaging-tools/
-├── templates/
-│   ├── debian/
-│   │   ├── control.j2
-│   │   ├── rules.j2
-│   │   ├── install.j2
-│   │   ├── postinst.j2
-│   │   ├── prerm.j2
-│   │   ├── postrm.j2
-│   │   ├── changelog.j2
-│   │   ├── copyright.j2
-│   │   └── compat
-│   └── systemd/
-│       └── service.j2
-└── schemas/
-    ├── metadata.py
-    └── config.py
+**Development Tools**:
+- pytest: Testing framework
+- ruff: Linting and formatting
+- ty: Type checking
+- Docker: Integration testing
 
-/usr/share/doc/container-packaging-tools/
-├── README.md
-├── EXAMPLES.md
-├── copyright
-└── changelog.gz
-```
-
-**Dependencies**:
-All dependencies are resolved by APT during installation:
-- Python runtime and libraries
-- Debian packaging tools
-- Docker (recommended for testing generated packages)
-
-### Execution Environment
-
-**Development**:
-- Developer workstations (macOS, Linux)
-- Docker containers for isolated testing
-- CI/CD runners (GitHub Actions)
-
-**Production**:
-- Build servers (dedicated or CI/CD)
-- Developer machines (ad-hoc package creation)
-- Automated pipelines (scheduled builds)
-
-**Target Deployment**:
-- Raspberry Pi 4/5 running Raspberry Pi OS (arm64)
-- Any Debian 12+ system (amd64, arm64)
-- Docker must be installed on target systems
+## Deployment Modes
 
-## Security Considerations
+**Development**: Run from source using `uv run` with immediate feedback
 
-### Input Validation
+**Installed**: Debian package installation to system Python site-packages
 
-**Threat**: Malicious input files could exploit validation or template rendering
-
-**Mitigation**:
-- Schema validation catches malformed input
-- No code execution from input files
-- File paths validated to prevent directory traversal
-- YAML safe loader used (no arbitrary code execution)
-
-### File System Access
-
-**Threat**: Tool might overwrite important files or access sensitive data
-
-**Mitigation**:
-- Tool only writes to specified output directory
-- No root privileges required for package generation
-- Generated packages follow standard Debian security practices
-- Maintainer scripts reviewed for security issues
-
-### Dependency Security
-
-**Threat**: Compromised dependencies could affect tool behavior
-
-**Mitigation**:
-- Only Debian stable dependencies (trusted, reviewed)
-- No external network dependencies
-- Minimal dependency surface area
-- Dependencies updated via Debian security process
-
-### Generated Package Security
-
-**Threat**: Generated packages might be insecure
-
-**Mitigation**:
-- Standard file permissions applied
-- No setuid/setgid binaries
-- Service runs as root (required for Docker) but follows best practices
-- User data in separate directories from application data
-- Configuration files not world-readable
-
-### Build Environment
-
-**Threat**: Build environment compromise could affect packages
-
-**Mitigation**:
-- Reproducible builds minimize attack surface
-- Build happens in isolated directory
-- Temporary files cleaned up properly
-- Build artifacts checksummed
-
-## Performance Considerations
-
-### Expected Performance
-
-**Typical Package Generation**:
-- Validation: < 1 second
-- Template rendering: < 1 second
-- Package building: 2-5 seconds
-- Total: < 10 seconds
-
-**Large Packages**:
-- With many screenshots/assets: < 20 seconds
-- Complex compose files: no significant impact
-
-### Optimization Strategies
-
-**I/O Optimization**:
-- Files loaded sequentially (small files, not a bottleneck)
-- Binary files copied efficiently
-- Temporary directory on fast storage
-
-**CPU Optimization**:
-- Single-threaded (sufficient for use case)
-- No CPU-intensive operations
-- Template rendering is fast for small templates
-
-**Memory Optimization**:
-- All input files fit in memory (typically < 1 MB)
-- No streaming required
-- Python garbage collection handles cleanup
-
-### Scalability
-
-**Concurrent Builds**:
-- Tool is stateless and safe for concurrent execution
-- Different output directories for parallel builds
-- No shared state between invocations
-
-**Batch Processing**:
-- Can process multiple apps in sequence or parallel
-- CI/CD can run multiple instances safely
-- No resource contention concerns
-
-## Extensibility and Future Enhancements
-
-### Extension Points
-
-**Custom Templates**:
-Future versions could support:
-- User-provided template overrides
-- Template includes and inheritance
-- Custom template functions
-
-**Plugin Architecture**:
-Potential plugin system for:
-- Custom validators
-- Alternative build backends
-- Post-processing hooks
-- Format converters
-
-**Configuration**:
-Future configuration file could specify:
-- Template directory overrides
-- Default values
-- Build options
-- Output formats
-
-### Phase 2+ Architecture Changes
-
-**AppStream Metadata**:
-- Add AppStream XML template
-- Generate desktop files for GUI apps
-- Include additional metadata fields
-
-**Multi-Architecture**:
-- Cross-compilation support
-- Architecture-specific templates
-- Multi-arch package generation
-
-**Package Signing**:
-- GPG integration for signing
-- Keyring management
-- Signature verification
-
-**Alternative Backends**:
-- Podman support as Docker alternative
-- containerd support
-- OCI bundle generation
-
-## Testing Strategy
-
-### Unit Testing
-
-**Component Tests**:
-- Validator: Test each validation rule independently
-- Loader: Test file parsing edge cases
-- Template Renderer: Test template logic
-- Path generator: Test path construction
-
-**Test Coverage Target**: >80%
-
-### Integration Testing
-
-**End-to-End Tests**:
-- Valid input → successful package
-- Invalid input → appropriate error
-- Generated package installs correctly
-- Service starts and stops properly
-- Package removes cleanly
-
-**Test Environments**:
-- Docker containers (Debian 12)
-- Raspberry Pi OS images
-- Multiple architecture emulation
-
-### Validation Testing
-
-**Schema Validation**:
-- Every schema rule has test case
-- Edge cases (min/max, boundaries)
-- Invalid format detection
-- Missing field detection
-
-### Package Testing
-
-**Generated Package Quality**:
-- Lintian checks pass
-- Files installed to correct locations
-- Permissions set correctly
-- Service unit is valid
-- Scripts execute without errors
-
-### Performance Testing
-
-**Benchmarks**:
-- Package generation time
-- Validation performance
-- Memory usage
-- Concurrent build handling
-
-## Error Handling Strategy
-
-### Error Categories
-
-**User Errors** (Exit 1):
-- Invalid input files
-- Schema violations
-- Missing required files
-Guidance: Clear message with correction suggestion
-
-**System Errors** (Exit 3):
-- Disk full
-- Permission denied
-- dpkg-buildpackage failure
-Guidance: System-level troubleshooting steps
-
-**Tool Errors** (Exit 2):
-- Template rendering failure
-- Internal logic errors
-Guidance: Bug report instructions
-
-**Dependency Errors** (Exit 4):
-- Missing system packages
-- Python import failures
-Guidance: Installation instructions
-
-### Error Message Format
-
-**Structure**:
-```
-ERROR: <Category>: <Problem>
-  File: <path>:<line>
-  Field: <field_name>
-  Current value: <value>
-  Expected: <expected_format>
-  Suggestion: <how_to_fix>
-```
-
-**Examples**:
-- Validation errors include file and line
-- Missing files show expected location
-- Build errors include dpkg output
-- Permission errors show required access
-
-## Monitoring and Observability
-
-### Logging
-
-**Log Levels**:
-- ERROR: Failures and fatal errors
-- WARNING: Potential issues
-- INFO: Major processing steps
-- DEBUG: Detailed execution trace
-
-**Log Output**:
-- Default: stderr (errors and warnings only)
-- Verbose: stdout (info messages)
-- Debug: stdout (all messages)
-
-### Metrics
-
-**Future Enhancements** (Phase 2+):
-- Build success/failure rates
-- Average build times
-- Common error types
-- Package generation statistics
-
-### Debugging
-
-**Debug Mode**:
-- Enable with --debug flag
-- Shows template rendering details
-- Preserves temporary build directory
-- Includes full stack traces
-
-**Troubleshooting**:
-- Validation mode for pre-flight checks
-- Dry-run mode for testing without building
-- Keep-temp flag for manual inspection
-
-## Documentation Strategy
-
-### User Documentation
-
-**README.md**:
-- Quick start guide
-- Installation instructions
-- Basic usage examples
-- Link to detailed docs
-
-**EXAMPLES.md**:
-- Complete working examples
-- Common use cases
-- Troubleshooting tips
-- Best practices
-
-**Man Page** (future):
-- Command reference
-- Option descriptions
-- Examples
-- See also section
-
-### Developer Documentation
-
-**Code Comments**:
-- Docstrings for all public functions
-- Inline comments for complex logic
-- Type hints throughout
-
-**Architecture Documentation**:
-- This document (ARCHITECTURE.md)
-- DESIGN.md for detailed designs
-- SPEC.md for requirements
-
-### Schema Documentation
-
-**Pydantic Models**:
-- Python docstrings for model classes
-- `Field` descriptions for each attribute
-- Examples provided via `Field`'s `example` parameter
-- Custom validators for complex validation logic
-
-## References
-
-### Internal Documentation
-
-- [SPEC.md](SPEC.md) - Technical specification
-- [DESIGN.md](DESIGN.md) - Detailed design
-- [META-PLANNING.md](../../META-PLANNING.md) - Project planning
-- [PROJECT_PLANNING_GUIDE.md](../../PROJECT_PLANNING_GUIDE.md) - Development workflow
-
-### External References
-
-- [Debian Policy Manual](https://www.debian.org/doc/debian-policy/) - Packaging standards
-- [debhelper Documentation](https://manpages.debian.org/testing/debhelper/debhelper.7.en.html) - Build helpers
-- [systemd Documentation](https://www.freedesktop.org/software/systemd/man/) - Service units
-- [Docker Compose Specification](https://docs.docker.com/compose/compose-file/) - Compose format
-- [Jinja2 Documentation](https://jinja.palletsprojects.com/) - Template engine
-- [JSON Schema](https://json-schema.org/) - Validation specification
-- [Pydantic Documentation](https://docs.pydantic.dev/) - Data validation and settings management
-
-## Document History
-
-- **2025-11-11**: Initial architecture document created for Phase 1 development
+**CI/CD**: Automated execution in GitHub Actions workflows
+
+## Document Organization
+
+Each major component has its own architecture document describing:
+
+- Component breakdown and responsibilities
+- Data models and schemas
+- Processing pipelines and workflows
+- Integration points
+- Security and performance considerations
+- Testing strategy
+
+## Navigation
+
+### Specifications (Requirements)
+- **[Main Specification Index](SPEC.md)**: Requirements overview
+- **[Package Generation Spec](PACKAGING_SPEC.md)**: Core tool requirements
+- **[CasaOS Converter Spec](CONVERTER_SPEC.md)**: Converter requirements
+
+### Architecture (Design)
+- **[Package Generation Architecture](PACKAGING_ARCHITECTURE.md)**: Core tool design
+- **[CasaOS Converter Architecture](CONVERTER_ARCHITECTURE.md)**: Converter design
+
+### Other Documentation
+- **[Design Document](DESIGN.md)**: Overall design and planning
+- **[Security](SECURITY.md)**: Security considerations
+
+## Design Principles
+
+### Modularity
+
+Components have clear responsibilities and well-defined interfaces. Each module can be tested and evolved independently.
+
+### Validation First
+
+Input is validated early using Pydantic schemas. Invalid input fails fast with clear error messages before processing begins.
+
+### Template-Based Generation
+
+Debian package files are generated from Jinja2 templates, allowing easy customization and maintenance without code changes.
+
+### Reusability
+
+Core packaging logic is reused across different input sources. The converter produces standard format consumed by the core packager.
+
+### Testability
+
+Each component has comprehensive unit tests. Integration tests verify end-to-end functionality. E2E tests validate actual package installation.
+
+## Extension Points
+
+The architecture supports future extensions:
+
+- **Additional Converters**: Runtipi, Umbrel, or custom formats following the converter interface
+- **Output Formats**: Alternative package formats or deployment methods
+- **Template Customization**: User-provided templates for specialized package requirements
+- **Validation Rules**: Custom validation beyond schema requirements
+
+## Development Workflow
+
+Architecture documents are created after specification approval following the [HaLOS Project Planning Guide](../../docs/PROJECT_PLANNING_GUIDE.md). Implementation must follow documented architecture.
+
+Changes to architecture require updates to these documents and review before implementation.
+
+---
+
+**Current Component Versions:**
+- Core Package Generation: v1.0
+- CasaOS Converter: v1.0 (Draft)

--- a/docs/CONVERTER_ARCHITECTURE.md
+++ b/docs/CONVERTER_ARCHITECTURE.md
@@ -1,0 +1,454 @@
+# CasaOS to HaLOS Converter - System Architecture
+
+**Version:** 1.0
+**Date:** 2025-11-26
+**Status:** Draft
+
+## Overview
+
+The CasaOS to HaLOS converter is a Python-based conversion system integrated into the container-packaging-tools package. It transforms CasaOS application definitions into HaLOS container store format, enabling rapid population of the HaLOS app catalog from the existing CasaOS ecosystem. The architecture emphasizes modularity, testability, and seamless integration with existing tooling.
+
+## System Components
+
+### Component Hierarchy
+
+The converter operates as a submodule within container-packaging-tools, extending its capabilities rather than replacing them:
+
+**Container Packaging Tools**
+- Core packaging engine (existing)
+- Schema models (existing)
+- **CasaOS Converter** (new)
+  - Parser layer
+  - Transformation layer
+  - Asset management
+  - Output generation
+
+### Component Descriptions
+
+#### CLI Extension
+
+The converter extends the existing generate-container-packages CLI with new commands for CasaOS conversion. It adds subcommands or flags that invoke the conversion pipeline before passing to the standard packaging pipeline.
+
+The CLI maintains consistency with existing command patterns while adding converter-specific options for batch processing, update detection, and source repository handling.
+
+#### CasaOS Parser
+
+The parser reads CasaOS docker-compose.yml files and extracts both standard Docker Compose configuration and x-casaos metadata extensions. It validates the input structure and normalizes it into internal data models.
+
+The parser handles two levels of CasaOS metadata: app-level metadata at the compose root and service-level metadata within individual services. It merges these into a unified representation for transformation.
+
+#### Metadata Transformer
+
+The transformer maps CasaOS structures to HaLOS structures using configurable mapping rules. It implements the core conversion logic: category mapping, field type inference, configuration grouping, and path transformation.
+
+The transformer makes intelligent decisions about field organization, generates appropriate validation rules, and enriches metadata with HaLOS-specific requirements. It applies the casaos- prefix to package names and tracks conversion provenance.
+
+#### Asset Manager
+
+The asset manager downloads icons and screenshots from URLs specified in CasaOS metadata. It implements caching, retry logic, validation, and parallel downloads for efficiency.
+
+The manager validates downloaded assets for format, size, and integrity. It handles network failures gracefully and maintains a cache to avoid repeated downloads during development and testing.
+
+#### Configuration Generator
+
+The configuration generator creates HaLOS config.yml files from CasaOS environment variable definitions. It organizes fields into logical groups, infers appropriate field types, and generates validation rules.
+
+The generator applies heuristics to determine grouping: network-related fields go together, authentication fields form another group, and storage configuration is separated. It creates sensible defaults and helpful descriptions.
+
+#### Output Writer
+
+The output writer creates the three HaLOS files with proper formatting and validation. It generates metadata.yaml, config.yml, and docker-compose.yml, ensuring each conforms to HaLOS schemas.
+
+The writer validates all output against Pydantic models before writing files. It handles file permissions, creates necessary directories, and provides detailed error messages for validation failures.
+
+#### Update Detector
+
+The update detector compares the current state of converted apps with the upstream CasaOS repository to identify changes. It tracks which apps are new, which have been updated, and which have been removed.
+
+The detector uses conversion timestamps and upstream commit hashes to determine what needs re-conversion. It generates sync reports showing exactly what changed and what actions are recommended.
+
+## Technology Stack
+
+### Core Technologies
+
+**Python 3.11+**: Implementation language matching Debian Trixie baseline for compatibility with existing container-packaging-tools codebase.
+
+**PyYAML**: YAML parsing and generation for all configuration files. Used for both reading CasaOS input and generating HaLOS output.
+
+**Pydantic v2**: Schema validation and data modeling. Reuses existing PackageMetadata and ConfigSchema models from container-packaging-tools.
+
+**requests**: HTTP client for downloading assets. Includes retry logic and timeout handling for reliability.
+
+### Development Tools
+
+**pytest**: Testing framework with fixtures. Integrates with existing container-packaging-tools test suite.
+
+**ruff**: Linting and formatting. Uses same configuration as container-packaging-tools for consistency.
+
+**ty**: Type checking. Ensures type safety across the converter codebase.
+
+**Docker**: Integration testing environment matching container-packaging-tools CI setup.
+
+### Optional Dependencies
+
+**tqdm**: Progress bars for batch conversion operations providing user feedback during long-running tasks.
+
+**Pillow**: Image validation and manipulation for icons and screenshots.
+
+## Data Models
+
+### Internal Models
+
+**CasaOSApp**: Represents a parsed CasaOS application with all metadata and configuration. Contains fields for:
+- App name, description, tagline
+- Category and tags
+- Service definitions
+- Environment variables with metadata
+- Port and volume configurations
+- Icon and screenshot URLs
+- Developer information
+
+**HaLOSPackage**: Target format representation containing all data needed for the three output files. Maps directly to metadata.yaml, config.yml, and docker-compose.yml structure.
+
+**ConversionContext**: State tracking object maintaining conversion progress, warnings, errors, downloaded assets, and transformation decisions. Enables detailed reporting and debugging.
+
+**UpdateReport**: Describes changes detected between current converted apps and upstream CasaOS repository. Lists new apps, updated apps, removed apps, and recommended actions.
+
+### Schema Integration
+
+The converter reuses existing Pydantic models from container-packaging-tools:
+
+**PackageMetadata**: Validates generated metadata.yaml ensuring all required fields are present and correctly formatted.
+
+**ConfigSchema**: Validates generated config.yml ensuring proper group and field structure.
+
+These models ensure converter output is immediately compatible with the packaging pipeline without additional validation layers.
+
+### Mapping Configuration
+
+**CategoryMap**: YAML configuration mapping CasaOS categories to HaLOS categories. Includes fallback rules for unknown categories.
+
+**FieldTypeRules**: YAML configuration defining heuristics for inferring config.yml field types from CasaOS environment variables.
+
+**PathTransformRules**: YAML configuration for converting CasaOS volume paths to HaLOS conventions.
+
+## Processing Pipeline
+
+### Single App Conversion Flow
+
+**Stage 1 - Input Loading**: Read CasaOS docker-compose.yml from directory or repository, parse YAML structure, validate basic syntax.
+
+**Stage 2 - Metadata Extraction**: Extract x-casaos metadata from root level, extract x-casaos metadata from service level, merge into unified CasaOSApp model.
+
+**Stage 3 - Validation**: Validate CasaOS structure against expected schema, check for required fields, verify container image references.
+
+**Stage 4 - Transformation**: Map category to HaLOS taxonomy, infer field types for environment variables, organize fields into logical groups, apply path transformations, generate package name with casaos- prefix.
+
+**Stage 5 - Asset Download**: Download icon from URL, download screenshots, validate formats and sizes, cache downloaded assets.
+
+**Stage 6 - Output Generation**: Create metadata.yaml with package metadata, create config.yml with field groups, create docker-compose.yml without x-casaos extensions, validate all outputs against schemas.
+
+**Stage 7 - Writing**: Write three files to output directory, set appropriate file permissions, generate conversion report.
+
+### Batch Conversion Flow
+
+For converting multiple apps from the CasaOS repository:
+
+**Initialization**: Clone or update CasaOS-AppStore repository, scan for all app directories, load previous conversion state.
+
+**App Discovery**: Identify all apps in repository, compare with previously converted apps, determine which apps need conversion.
+
+**Parallel Processing**: Process multiple apps concurrently up to configured limit, track progress with status updates, collect warnings and errors.
+
+**Aggregation**: Generate summary statistics, create batch report, identify systematic issues, recommend manual review cases.
+
+### Update Synchronization Flow
+
+For re-running converter on updated upstream:
+
+**State Comparison**: Load conversion timestamps from existing apps, fetch latest commit from CasaOS repository, identify modified apps.
+
+**Change Detection**: Determine new apps to convert, determine updated apps to reconvert, determine removed apps to flag.
+
+**Conflict Handling**: Check for manual modifications to existing converted apps, warn about conflicts between local changes and upstream updates, provide options for resolution.
+
+**Selective Conversion**: Convert only changed apps unless full reconversion requested, preserve manually edited apps unless overridden, generate detailed sync report.
+
+## File Structure
+
+### Repository Integration
+
+The converter integrates into container-packaging-tools with this structure:
+
+```
+container-packaging-tools/
+├── src/
+│   └── generate_container_packages/
+│       ├── converters/              # New converter subsystem
+│       │   ├── __init__.py
+│       │   ├── base.py              # Base converter interface
+│       │   └── casaos/
+│       │       ├── __init__.py
+│       │       ├── parser.py
+│       │       ├── transformer.py
+│       │       ├── assets.py
+│       │       ├── generator.py
+│       │       ├── updater.py
+│       │       └── models.py
+│       ├── cli.py                   # Extended with converter commands
+│       └── ... (existing modules)
+├── mappings/                        # New configuration directory
+│   └── casaos/
+│       ├── categories.yaml
+│       ├── field_types.yaml
+│       └── paths.yaml
+├── tests/
+│   ├── converters/                  # New test directory
+│   │   └── casaos/
+│   │       ├── fixtures/
+│   │       │   ├── valid/
+│   │       │   │   ├── jellyfin/
+│   │       │   │   └── signalk/
+│   │       │   └── invalid/
+│   │       ├── test_parser.py
+│   │       ├── test_transformer.py
+│   │       ├── test_assets.py
+│   │       ├── test_generator.py
+│   │       └── test_integration.py
+│   └── ... (existing tests)
+└── docs/
+    ├── CONVERTER_SPEC.md
+    ├── CONVERTER_ARCHITECTURE.md
+    └── ... (existing docs)
+```
+
+### Configuration Files
+
+Mapping files live in mappings/casaos/ and use YAML format for easy editing without code changes.
+
+**categories.yaml**: Maps CasaOS categories to HaLOS. Example structure:
+```yaml
+mappings:
+  Entertainment: media
+  Media: media
+  Productivity: productivity
+  Developer: development
+default: utilities
+```
+
+**field_types.yaml**: Rules for field type inference. Example structure:
+```yaml
+patterns:
+  - pattern: ".*PORT$"
+    type: integer
+    validation: {min: 1024, max: 65535}
+  - pattern: ".*PASSWORD$"
+    type: password
+  - pattern: ".*_DIR$|.*_PATH$"
+    type: path
+```
+
+**paths.yaml**: Path transformation rules. Example structure:
+```yaml
+transforms:
+  - from: "/DATA/AppData/{app}/"
+    to: "${CONTAINER_DATA_ROOT}/"
+```
+
+## Integration Points
+
+### Container Packaging Tools Integration
+
+The converter produces output that feeds directly into the existing packaging pipeline. After conversion, the metadata.yaml, config.yml, and docker-compose.yml are processed by the standard package generation logic.
+
+CLI integration adds converter commands while maintaining backward compatibility. Existing commands continue to work unchanged. New commands like `generate-container-packages convert-casaos` invoke the conversion pipeline.
+
+### CasaOS Repository Access
+
+The converter accesses the official CasaOS-AppStore GitHub repository. It can operate on a local clone or fetch directly from GitHub. Repository operations use standard git commands or GitHub API.
+
+The converter tracks the repository commit hash in converted app metadata, enabling change detection during updates.
+
+### HaLOS Container Store Output
+
+Converted apps are written to a specified output directory organized by app. Each app gets its own subdirectory containing the three required files plus assets.
+
+The output structure is compatible with both halos-marine-containers repository and any general container store repository following HaLOS conventions.
+
+### Build Pipeline Integration
+
+The converter integrates with CI/CD workflows. It can be invoked from GitHub Actions to automate conversion on schedule or webhook trigger.
+
+Exit codes and structured logging enable CI integration. The converter reports success, warnings, and failures in a machine-parseable format.
+
+## Deployment Architecture
+
+### Development Mode
+
+Developers run the converter from source using `uv run` or direct Python invocation. Changes to mapping files take effect immediately without reinstallation.
+
+The development mode includes verbose logging, detailed error messages, and access to all intermediate data for debugging.
+
+### Installed Mode
+
+The converter is included in the container-packaging-tools Debian package. Installation places the converter module in Python site-packages and makes commands available system-wide.
+
+Configuration files install to /usr/share/container-packaging-tools/mappings/ with user overrides supported in /etc/container-packaging-tools/.
+
+### CI/CD Mode
+
+GitHub Actions workflows invoke the converter with specific flags for automated operation. The converter runs in batch mode with structured output suitable for automated processing.
+
+Converted apps can be automatically committed to repositories, trigger package builds, and notify maintainers of issues requiring manual review.
+
+## Security Considerations
+
+### Input Validation
+
+All YAML input is parsed with safe_load to prevent code execution. The converter does not evaluate or execute any content from CasaOS files.
+
+Docker Compose configurations are parsed but never executed during conversion. Malicious compose files cannot compromise the conversion process.
+
+### Asset Downloads
+
+Downloads use HTTPS where available and validate content types before accepting. Size limits prevent resource exhaustion from malicious URLs.
+
+The converter validates that downloaded images are actual image files with correct magic bytes, not executables with image extensions.
+
+### Output Safety
+
+Generated files are validated against schemas before writing. The converter cannot produce malformed output that might exploit downstream tools.
+
+File permissions are set appropriately: configuration files get 0644, directories get 0755. No files are created with execute permissions.
+
+### Credential Handling
+
+The converter does not require credentials for public CasaOS repository access. If private repositories are supported in future, credentials are handled through environment variables or credential managers, never hardcoded or logged.
+
+## Performance Considerations
+
+### Parallelization Strategy
+
+Asset downloads are parallelized using thread pools. Multiple downloads occur simultaneously with configurable concurrency limits.
+
+Batch app conversion can process multiple apps in parallel using process pools for CPU-bound transformation work. Parallelization respects system resource limits.
+
+### Caching Strategy
+
+Downloaded assets are cached by URL hash in a local cache directory. The cache persists across converter runs, eliminating redundant downloads.
+
+HTTP cache headers are respected when available. The cache implements LRU eviction when size limits are reached.
+
+Parsed CasaOS apps can be cached to accelerate re-runs during development. The cache invalidates on file modification time changes.
+
+### Resource Limits
+
+Memory usage per app conversion is bounded. Large compose files or metadata do not cause unbounded memory growth.
+
+Disk usage is dominated by downloaded assets. The converter monitors disk space and warns if running low.
+
+Timeouts prevent hung operations. Network operations timeout after 30 seconds per attempt. Total conversion time per app is limited to prevent resource leaks.
+
+## Testing Strategy
+
+### Unit Testing
+
+Each module has dedicated unit tests with mocked dependencies. Parser tests verify handling of various CasaOS formats. Transformer tests validate mapping logic. Generator tests check output correctness.
+
+Unit tests use pytest fixtures for test data. Coverage target is 80% of converter code.
+
+### Integration Testing
+
+Integration tests run full conversion on realistic CasaOS apps from fixtures. Tests verify end-to-end functionality with actual CasaOS files.
+
+Integration tests validate that output passes schema validation and can be packaged by container-packaging-tools.
+
+### End-to-End Testing
+
+E2E tests take converted apps through complete pipeline: conversion, packaging, installation in Docker container, service startup verification.
+
+These tests run in Docker containers matching target Debian environment, ensuring deployment compatibility.
+
+### Regression Testing
+
+Golden test cases capture known good conversions. Any changes to converter logic are validated against golden outputs to detect regressions.
+
+Golden tests cover diverse apps: simple apps, complex apps with many options, apps using various CasaOS features.
+
+## Monitoring and Logging
+
+### Logging Implementation
+
+The converter uses Python logging module with multiple levels. Logger names follow hierarchical pattern: `generate_container_packages.converters.casaos.parser` for fine-grained control.
+
+Log output includes timestamps, module names, and context about which app is being processed.
+
+### Metrics Collection
+
+Batch conversion collects statistics: total apps, successful conversions, failures, warnings, assets downloaded, total bytes downloaded, elapsed time.
+
+These metrics are reported at completion and optionally exported in JSON format for monitoring systems.
+
+### Traceability
+
+Every converted app includes source metadata: converter version, conversion timestamp, CasaOS repository URL, CasaOS repository commit hash, original CasaOS app ID.
+
+This metadata enables auditing, troubleshooting, and future synchronization with upstream.
+
+## Extensibility
+
+### Converter Interface
+
+A base converter interface is defined to enable future converters for other sources like Runtipi. The interface specifies required methods: parse, transform, generate.
+
+CasaOS converter implements this interface. Future converters can reuse common components like asset management and output generation.
+
+### Mapping Customization
+
+YAML mapping files provide declarative customization without code changes. Users can override mappings by placing custom files in configuration directories.
+
+The converter loads mappings from multiple locations with precedence: user overrides, system defaults, built-in defaults.
+
+### Plugin Hooks
+
+While not implemented in v1, the architecture allows for future plugin hooks. Plugins could customize conversion for specific apps, add validation rules, or modify output.
+
+## Development Workflow
+
+### Feature Development
+
+New converter features are developed in feature branches following container-packaging-tools workflow. Pull requests require tests, documentation, and code review.
+
+The converter code follows same quality standards as container-packaging-tools: type hints, docstrings, ruff formatting, ty type checking.
+
+### Testing Requirements
+
+All new code requires unit tests. Complex features require integration tests. Breaking changes or major features require E2E tests.
+
+CI runs full test suite on every push. Tests must pass before merge to main.
+
+### Documentation Standards
+
+Code is documented with docstrings following Google style. User-facing features require documentation updates in README or dedicated docs.
+
+Significant design decisions are captured in architecture decision records for future reference.
+
+## Migration and Rollout
+
+### Initial Conversion
+
+The first conversion run processes all CasaOS apps, generating a complete catalog. Manual review identifies apps needing customization.
+
+A staged rollout converts a subset first for validation, then expands to full catalog once conversion quality is confirmed.
+
+### Ongoing Synchronization
+
+After initial conversion, regular sync runs keep the catalog current. Automated or scheduled runs can be established once quality is proven.
+
+Manual review focuses on new apps and significantly changed apps. Minor updates can be automatically applied.
+
+### Quality Assurance
+
+Converted apps undergo validation: schema compliance, package build success, installation testing, basic functionality verification.
+
+Apps failing validation are flagged for manual review and excluded from automated publishing until fixed.

--- a/docs/CONVERTER_SPEC.md
+++ b/docs/CONVERTER_SPEC.md
@@ -1,0 +1,305 @@
+# CasaOS to HaLOS Container Store Converter - Technical Specification
+
+**Version:** 1.0
+**Date:** 2025-11-25
+**Status:** Draft
+
+## Project Overview
+
+The CasaOS to HaLOS Container Store Converter is a command-line tool that automatically converts application definitions from the CasaOS app store format into the HaLOS container store format. This enables rapid population of the HaLOS container store with hundreds of pre-existing applications without manual conversion work.
+
+### Goals
+
+1. **Automation**: Convert CasaOS app definitions to HaLOS format without manual intervention
+2. **Accuracy**: Preserve all relevant metadata, configuration, and functionality during conversion
+3. **Completeness**: Handle icons, screenshots, and all metadata fields
+4. **Quality**: Generate valid HaLOS packages that pass all validation checks
+5. **Maintainability**: Support ongoing synchronization with upstream CasaOS app store
+6. **Transparency**: Track conversion provenance and enable manual review
+
+## Background
+
+The HaLOS project needs a large catalog of containerized applications to provide value to users. Rather than manually creating hundreds of application definitions, we can leverage the existing CasaOS app store which contains well-maintained application definitions with metadata, icons, and screenshots.
+
+CasaOS uses a Docker Compose-based format with custom metadata extensions. HaLOS uses a similar approach but with different metadata organization. The formats are compatible enough that automated conversion is feasible with high fidelity.
+
+## Core Features
+
+### Input Processing
+
+The converter accepts CasaOS application definitions as input. Each CasaOS app consists of a docker-compose.yml file containing both the container configuration and metadata embedded as x-casaos extensions.
+
+The converter must parse and validate the CasaOS format, extracting both the container definitions and the rich metadata that describes the application's purpose, configuration options, and user interface.
+
+### Metadata Transformation
+
+CasaOS stores metadata in two locations within the docker-compose.yml: app-level metadata at the root under x-casaos, and service-level metadata under each service's x-casaos section.
+
+The converter transforms this embedded metadata into the HaLOS format, which separates concerns into three files: metadata.yaml for package information, config.yml for user configuration schema, and docker-compose.yml for container definitions.
+
+Key transformations include:
+- Extracting app name, description, and tagline
+- Converting category taxonomies between systems
+- Transforming environment variable configurations into structured field definitions
+- Mapping port and volume configurations
+- Preserving developer information and links
+
+### Configuration Schema Generation
+
+CasaOS defines configuration through environment variable descriptions in the x-casaos metadata. The converter must transform these into the HaLOS config.yml format, which organizes fields into logical groups with rich type definitions.
+
+The converter infers field types from CasaOS type annotations and descriptions, generates appropriate validation rules, and organizes fields into sensible groups like Network Settings, Storage, and Authentication.
+
+### Docker Compose Conversion
+
+The container definitions in CasaOS docker-compose.yml must be converted to HaLOS format. This involves:
+- Removing x-casaos metadata extensions from the compose file
+- Converting CasaOS-specific variable references to HaLOS conventions
+- Adjusting volume paths from CasaOS conventions to HaLOS paths
+- Ensuring restart policies are removed (systemd handles lifecycle in HaLOS)
+- Preserving all functional container configuration
+
+### Asset Management
+
+CasaOS apps reference icons and screenshots via URLs. The converter must download these assets and include them in the output directory for packaging.
+
+Icons must be validated for correct size and format. Screenshots should be downloaded and organized appropriately. The converter handles missing assets gracefully with warnings rather than failures.
+
+### Source Tracking and Update Support
+
+Every converted app must include metadata tracking its origin from CasaOS. This includes the original app ID, upstream repository URL, conversion timestamp, and any conversion notes or warnings.
+
+The converter must support re-running on an updated CasaOS repository to sync with upstream changes. When re-run, it should:
+- Detect which apps have been added, updated, or removed in the upstream CasaOS store
+- Re-convert updated apps with new metadata and container definitions
+- Preserve any manual customizations by warning when conflicts are detected
+- Generate a sync report showing what changed
+
+This enables keeping the HaLOS container store current with the latest CasaOS apps and updates.
+
+## Technical Requirements
+
+### Input Format Support
+
+The converter must correctly parse Docker Compose v3.x format with CasaOS x-casaos extensions. It must handle both app-level and service-level metadata.
+
+The converter must validate input against the CasaOS schema before attempting conversion, providing clear error messages for invalid or incomplete CasaOS definitions.
+
+### Output Format Compliance
+
+Generated metadata.yaml files must pass HaLOS schema validation using the PackageMetadata Pydantic model. All required fields must be present with valid values.
+
+Generated config.yml files must conform to the HaLOS configuration schema with version 1.0 format, properly structured groups and fields.
+
+Generated docker-compose.yml files must be valid Docker Compose format suitable for use with HaLOS container management.
+
+### Category Mapping
+
+The converter implements a mapping table between CasaOS category names and HaLOS categories. CasaOS categories like "Entertainment" and "Media" map to HaLOS "media" category. "Productivity" and "Cloud" map to "productivity". "Developer" maps to "development".
+
+Unmapped categories should be handled with a default mapping and a warning message to allow manual review.
+
+### Field Type Inference
+
+The converter must infer appropriate field types for config.yml from CasaOS environment variable definitions. CasaOS "number" type maps to "integer" type. Text fields may be "string", "password", or "path" depending on the variable name and description.
+
+Port fields are identified by naming patterns and configured with appropriate validation ranges. Boolean fields are detected from default values and descriptions.
+
+### Asset Download
+
+The converter must download icons from URLs specified in CasaOS metadata. Icon downloads should validate image format and dimensions, preferring SVG when available.
+
+Screenshot downloads should handle multiple screenshots per app. Failed downloads generate warnings but do not fail the conversion, allowing manual asset addition later.
+
+Network errors during download should be retried with exponential backoff. The converter should support caching of downloaded assets to avoid repeated downloads during development.
+
+### Package Naming
+
+Package names must follow HaLOS conventions with a source prefix to avoid conflicts. The format is: `casaos-<app-name>-container`.
+
+The app name is derived from the CasaOS app name: all lowercase, spaces removed, and special characters converted to hyphens. For example, CasaOS app "Signal K" becomes `casaos-signalk-container`.
+
+The "casaos-" prefix clearly identifies the package source and prevents naming conflicts with packages converted from other sources like Runtipi or manually created marine apps.
+
+Package names must be validated against Debian naming rules and checked for uniqueness in the target repository.
+
+### Version Handling
+
+The converter extracts version information from CasaOS container image tags when available. If no version is specified, it uses a default version with a note for manual review.
+
+Version numbers must be normalized to Debian-compatible format, removing any incompatible characters or prefixes.
+
+## Non-Functional Requirements
+
+### Performance
+
+The converter should process a single app in under 5 seconds excluding asset downloads. Batch conversion of 100 apps should complete in under 10 minutes.
+
+Asset downloads should be parallelized to minimize total conversion time. The converter should support concurrent processing of multiple apps.
+
+### Reliability
+
+The converter must handle errors gracefully without crashing. Invalid input should produce clear error messages indicating what is wrong and how to fix it.
+
+Partial failures (like missing screenshots) should allow the conversion to complete with warnings. The converter should never produce invalid HaLOS packages that fail validation.
+
+### Usability
+
+The command-line interface should be intuitive with sensible defaults. Progress indicators should show conversion status for batch operations.
+
+Verbose output mode should provide detailed information about conversion decisions and transformations. Quiet mode should suppress all non-error output.
+
+### Maintainability
+
+The codebase should be modular with clear separation between parsing, transformation, and output generation. Each component should be independently testable.
+
+The category mapping and field type inference rules should be configurable through external files to enable updates without code changes.
+
+## Out of Scope
+
+### Not Included
+
+The following are explicitly out of scope for the initial version:
+
+**Runtipi Conversion**: This spec focuses solely on CasaOS conversion. Runtipi conversion will be a separate tool with similar architecture but different input parsing.
+
+**Fully Automated Update Pipeline**: While the converter supports re-running on updated upstream repositories, automatic detection and triggering of conversions (e.g., via webhooks or scheduled jobs) is a future enhancement. The initial version requires manual invocation to sync with upstream updates.
+
+**Multi-Architecture Handling**: The converter assumes apps support all architectures. Architecture-specific handling is deferred to future versions.
+
+**Interactive Configuration**: The tool operates in batch mode. Interactive prompts for ambiguous conversions are not supported in v1.
+
+**Package Building**: The converter outputs HaLOS app definitions ready for packaging. Actual Debian package generation uses the existing container-packaging-tools.
+
+**Repository Publishing**: Uploading converted packages to apt repositories is handled by separate CI/CD infrastructure.
+
+### Future Enhancements
+
+Potential future features include:
+- Interactive mode for reviewing and adjusting conversions
+- Diff tool to compare CasaOS updates with existing HaLOS definitions
+- Statistics and quality metrics for conversion batches
+- Integration with GitHub Actions for automated conversion pipelines
+- Support for custom conversion rules per-app
+- Automatic detection of apps suitable for marine category
+
+## Success Criteria
+
+### Functional Criteria
+
+A successful conversion produces:
+- Valid metadata.yaml passing HaLOS schema validation
+- Valid config.yml with appropriate field types and groups
+- Valid docker-compose.yml suitable for HaLOS deployment
+- Downloaded icons and screenshots in correct formats
+- Complete source tracking metadata
+
+### Quality Criteria
+
+Converted apps must:
+- Install successfully using container-packaging-tools
+- Start correctly under systemd management
+- Display properly in Cockpit package manager
+- Function identically to original CasaOS version
+- Include all user-configurable options from CasaOS
+
+### Coverage Criteria
+
+The converter should successfully convert:
+- At least 95% of apps from the official CasaOS app store
+- All common configuration field types
+- All common category mappings
+- Apps with multiple screenshots
+- Apps with complex environment configurations
+
+## Key Assumptions
+
+### Technical Assumptions
+
+We assume that CasaOS docker-compose.yml files are valid and follow documented CasaOS conventions. We assume icon and screenshot URLs are publicly accessible.
+
+We assume the HaLOS container packaging tools are available and functional. We assume the target system has internet access for asset downloads.
+
+### Business Assumptions
+
+We assume that automatically converting CasaOS apps is legally permissible, as both projects are open source. We assume that CasaOS developers will not object to their metadata being converted to other formats.
+
+We assume that the effort to manually review converted apps is acceptable. We assume that some manual fixup of converted apps is expected and planned for.
+
+### Compatibility Assumptions
+
+We assume that Docker Compose features used by CasaOS apps are compatible with HaLOS deployment. We assume that volume path differences can be transparently handled through variable substitution.
+
+We assume that port mappings and network modes used by CasaOS work in HaLOS environments.
+
+## Constraints
+
+### Platform Constraints
+
+The converter must run on Python 3.11+ to match Debian Trixie requirements. It must use only dependencies available in Debian repositories or via pip.
+
+The converter must produce output compatible with container-packaging-tools which runs on Debian-based systems.
+
+### Data Constraints
+
+Icon files must not exceed 5MB. Screenshot files must not exceed 10MB per image. The total size of downloaded assets per app should not exceed 50MB.
+
+### Time Constraints
+
+Asset downloads must timeout after 30 seconds per file. Total conversion time per app should not exceed 60 seconds to keep batch operations reasonable.
+
+### Legal Constraints
+
+The converter must respect copyright and licensing. All converted apps must include proper attribution to original creators. The converter must preserve license information from CasaOS definitions.
+
+## Acceptance Criteria
+
+The converter is considered complete when:
+
+1. It can parse all well-formed CasaOS docker-compose.yml files
+2. It generates HaLOS packages that pass validation
+3. Converted packages install and run correctly on HaLOS systems
+4. At least 50 CasaOS apps have been successfully converted and tested
+5. Documentation covers installation, usage, and troubleshooting
+6. Test coverage exceeds 80% for core conversion logic
+7. All GitHub issues from TASKS.md are completed
+8. Code review by maintainers is approved
+9. CI/CD pipeline builds and tests successfully
+10. User-facing documentation is published
+
+## Dependencies
+
+### External Dependencies
+
+The converter depends on:
+- Python 3.11+ standard library
+- PyYAML for YAML parsing and generation
+- Pydantic for schema validation (HaLOS models)
+- requests library for HTTP downloads
+- Jinja2 for template rendering (if used)
+
+### Internal Dependencies
+
+The converter relies on:
+- container-packaging-tools schemas (PackageMetadata, ConfigSchema)
+- HaLOS container store format documentation
+- CasaOS app store format documentation
+
+### System Dependencies
+
+Runtime requires:
+- Internet access for asset downloads
+- Write access to output directory
+- Sufficient disk space for downloaded assets
+
+Development requires:
+- pytest for testing
+- Docker for integration testing
+- Access to CasaOS app store repository for test data
+
+## Related Documentation
+
+- **HaLOS Container Format**: halos-marine-containers/docs/DESIGN.md
+- **Container Packaging Tools**: container-packaging-tools/docs/DESIGN.md
+- **CasaOS App Store**: https://github.com/IceWhaleTech/CasaOS-AppStore/blob/main/CONTRIBUTING.md
+- **General Container Store Architecture**: docs/archive/CONTAINER_STORE_PLAN.md

--- a/docs/PACKAGING_ARCHITECTURE.md
+++ b/docs/PACKAGING_ARCHITECTURE.md
@@ -1,0 +1,868 @@
+# Container Packaging Tools - System Architecture
+
+**Status**: Draft
+**Version**: 1.0
+**Date**: 2025-11-11
+**Last Updated**: 2025-11-11
+
+## Document Purpose
+
+This document describes the system architecture of the Container Packaging Tools project. It details the components, their relationships, data models, technology decisions, and deployment considerations.
+
+## System Overview
+
+### Architectural Style
+
+Container Packaging Tools follows a **pipeline architecture** pattern where input data flows through a series of processing stages to produce output artifacts. The system is designed as a single-process command-line application with no external dependencies or network communication.
+
+### High-Level Architecture
+
+```
+Input Directory          Tool Pipeline              Output Directory
+┌──────────────┐        ┌─────────────┐            ┌──────────────┐
+│ metadata.yaml│───────>│  Validator  │            │              │
+│ compose.yml  │        └──────┬──────┘            │              │
+│ config.yml   │               │                   │              │
+│ (optional)   │        ┌──────▼──────┐            │              │
+│ icon.svg/png │───────>│   Loader    │            │              │
+│ screenshots  │        └──────┬──────┘            │              │
+└──────────────┘               │                   │              │
+                        ┌──────▼──────┐            │              │
+                        │  Template   │            │              │
+                        │  Renderer   │            │              │
+                        └──────┬──────┘            │              │
+                               │                   │              │
+                        ┌──────▼──────┐            │              │
+                        │  Package    │            │  .deb file   │
+                        │  Builder    │───────────>│  .buildinfo  │
+                        └─────────────┘            │  .changes    │
+                                                   └──────────────┘
+```
+
+## Core Components
+
+### 1. Command-Line Interface (CLI)
+
+**Purpose**: Parse command-line arguments and orchestrate the pipeline
+
+**Responsibilities**:
+- Parse and validate command-line arguments
+- Set up logging and verbosity levels
+- Initialize other components with configuration
+- Handle top-level exceptions and exit codes
+- Display progress and status messages
+
+**Key Design Decisions**:
+- Uses Python argparse for standard Unix-style CLI
+- Supports both positional (input directory) and optional arguments
+- Exit codes indicate specific error categories for scripting
+- Help text generated automatically from argument definitions
+
+**Interactions**:
+- Calls Validator with input directory path
+- Calls Loader to read and parse input files
+- Calls Template Renderer with loaded data
+- Calls Package Builder with rendered files
+- Reports errors and success messages to user
+
+### 2. Input Validator
+
+**Purpose**: Validate all input files before processing
+
+**Responsibilities**:
+- Check required files exist (metadata.yaml, docker-compose.yml, config.yml)
+- Validate JSON and YAML syntax
+- Validate using Pydantic models
+- Perform cross-file consistency checks
+- Collect and format validation errors
+
+**Key Design Decisions**:
+- Fails fast on first validation error (or collects all errors with --strict)
+- Uses Pydantic models for type-safe validation with Python type hints
+- Custom validators for cross-file checks
+- Clear error messages with file paths and line numbers
+
+**Validation Stages**:
+
+**Stage 1 - File Presence**:
+- Verify required files exist
+- Check optional file paths if referenced in metadata
+- Validate file permissions (readable)
+
+**Stage 2 - Syntax Validation**:
+- Parse JSON files with error recovery
+- Parse YAML files with error recovery
+- Check Docker Compose schema version
+
+**Stage 3 - Schema Validation**:
+- Validate metadata.yaml using Pydantic model
+- Validate config.yml using Pydantic model
+- Check required fields present
+- Validate format constraints (names, versions, emails)
+
+**Stage 4 - Cross-Validation**:
+- Verify package name ends with `-container`
+- Check tags include `role::container-app`
+- Ensure config field IDs match environment variables
+- Validate referenced files exist (icons, screenshots)
+
+**Interactions**:
+- Reads schema files from installed schemas directory
+- Returns validation results to CLI
+- Provides detailed error context for user feedback
+
+### 3. File Loader
+
+**Purpose**: Load and parse validated input files
+
+**Responsibilities**:
+- Load and parse YAML files (metadata, compose, config)
+- Copy binary files (icons, screenshots)
+- Build internal data model
+- Handle file encoding issues
+
+**Key Design Decisions**:
+- Assumes files are valid (validation already passed)
+- Loads all data into memory (files are small)
+- Preserves original YAML structure for templates
+- Uses UTF-8 encoding for all text files
+
+**Data Model**:
+The Loader produces a unified data structure containing:
+- Parsed metadata (Python dict from YAML)
+- Docker Compose configuration (Python dict from YAML)
+- Configuration schema (Python dict from YAML)
+- File paths to binary assets
+- Computed values (timestamps, tool version)
+
+**Interactions**:
+- Reads files from input directory
+- Passes data model to Template Renderer
+- Reports file loading errors to CLI
+
+### 4. Template Renderer
+
+**Purpose**: Generate package files from templates and metadata
+
+**Responsibilities**:
+- Load Jinja2 templates from installed location
+- Create template context from data model
+- Render each template file
+- Format multi-line text for Debian control files
+- Handle optional template sections
+
+**Key Design Decisions**:
+- Uses Jinja2 for powerful, maintainable templates
+- Templates are separate from code for easy customization
+- All template data passed as context dictionary
+- Templates handle missing optional fields gracefully
+
+**Template Types**:
+
+**Debian Control Files**:
+- debian/control: Package metadata and dependencies
+- debian/rules: Build rules (mostly static)
+- debian/install: File installation mappings
+- debian/compat: Debhelper compatibility (static)
+- debian/copyright: License and copyright info
+- debian/changelog: Package changelog
+
+**Maintainer Scripts**:
+- debian/postinst: Post-installation (service setup)
+- debian/prerm: Pre-removal (service stop)
+- debian/postrm: Post-removal (cleanup)
+
+**systemd Integration**:
+- debian/package-name.service: Service unit file
+
+**Application Files**:
+- env.template: Environment variable defaults
+
+**Template Context Structure**:
+The context passed to templates includes:
+- package: All package metadata (name, version, description, etc.)
+- service: systemd service configuration
+- paths: Standard installation paths
+- web_ui: Web interface configuration
+- default_config: Default environment variables
+- timestamp: Build timestamp
+- tool_version: Tool version for tracking
+
+**Interactions**:
+- Loads templates from `/usr/share/container-packaging-tools/templates/`
+- Receives data model from Loader
+- Writes rendered files to build directory
+- Reports rendering errors to CLI
+
+### 5. Package Builder
+
+**Purpose**: Build Debian package using dpkg-buildpackage
+
+**Responsibilities**:
+- Create build directory structure
+- Copy source files to build directory
+- Copy rendered templates to debian/ subdirectory
+- Invoke dpkg-buildpackage with appropriate flags
+- Move generated packages to output directory
+- Clean up temporary build artifacts
+
+**Key Design Decisions**:
+- Uses standard Debian tools (no custom package building)
+- Generates binary-only unsigned packages by default
+- Preserves build directory on failure for debugging
+- Captures build output for error reporting
+
+**Build Process Flow**:
+
+**Step 1 - Preparation**:
+- Create temporary build directory
+- Create debian/ subdirectory
+- Copy input files (metadata, compose, config, icons)
+
+**Step 2 - File Installation**:
+- Write rendered templates to debian/
+- Set executable permissions on debian/rules
+- Set executable permissions on maintainer scripts
+
+**Step 3 - Package Building**:
+- Execute dpkg-buildpackage with flags: -b -us -uc
+- Capture stdout and stderr
+- Monitor exit code
+
+**Step 4 - Artifact Collection**:
+- Move .deb file to output directory
+- Move .buildinfo and .changes files to output directory
+- Preserve or clean build directory based on flags
+
+**Interactions**:
+- Receives rendered files from Template Renderer
+- Invokes system dpkg-buildpackage command
+- Reports build progress and errors to CLI
+- Returns package file paths on success
+
+## Data Models
+
+### Metadata Model
+
+**Source**: metadata.yaml
+
+**Structure**:
+The metadata model contains all package-level information:
+- Identity: name, package_name, version, upstream_version
+- Description: description, long_description, homepage
+- Maintenance: maintainer, license
+- Classification: tags, debian_section, architecture
+- Dependencies: depends, recommends, suggests
+- Web UI: enabled, path, port, protocol
+- Configuration: default_config (environment variables)
+- Assets: icon, screenshots
+
+**Validation Rules**:
+- Package name must match pattern: lowercase, hyphens, must end with `-container`
+- Version must be valid Debian version (semver, date-based, CalVer, or hybrid)
+- Maintainer must match pattern: `Name <email@domain>`
+- Tags must include `role::container-app`
+- All fields must conform to JSON schema
+
+### Docker Compose Model
+
+**Source**: docker-compose.yml
+
+**Structure**:
+Standard Docker Compose v3.8+ format containing:
+- Services: Container definitions with images, ports, volumes, environment
+- Volumes: Bind mounts for persistent data (not named volumes)
+- Networks: Custom networks (optional)
+
+**Usage**:
+- Copied verbatim to package (not parsed or modified)
+- Used by systemd service for container lifecycle
+- Environment variables substituted at runtime from env file
+
+**Integration Points**:
+- Environment variables referenced with ${VAR:-default} syntax
+- Use `${CONTAINER_DATA_ROOT}` for bind mount paths (auto-set to `/var/lib/container-apps/<package>/data`)
+- Container name should be meaningful for management
+- No restart policy (systemd manages lifecycle)
+
+**System-Managed Variables**:
+The following environment variables are automatically injected into the env file:
+- `CONTAINER_DATA_ROOT`: Base path for container data storage (`/var/lib/container-apps/<package>/data`). Use this for all bind mount paths to keep container data separate from package files.
+
+### Configuration Schema Model
+
+**Source**: config.yml
+
+**Structure**:
+Hierarchical configuration definition:
+- Version: Schema version (currently "1.0")
+- Groups: Array of field groups
+  - Group ID: Identifier (lowercase_snake_case)
+  - Group Label: Display name
+  - Group Description: Help text (optional)
+  - Fields: Array of field definitions
+    - Field ID: Environment variable name (UPPER_SNAKE_CASE)
+    - Field Label: Display name
+    - Field Type: Data type (string, integer, boolean, enum, path, password)
+    - Default: Default value
+    - Required: Whether field is required
+    - Constraints: min, max, options (type-dependent)
+    - Description: Help text
+
+**Purpose**:
+- Defines user-configurable parameters
+- Used by Cockpit UI (Phase 2) for configuration forms
+- Drives environment variable generation in env file
+
+**Field Types**:
+- string: Text input
+- integer: Numeric input with optional min/max
+- boolean: Checkbox or toggle
+- enum: Select from predefined options
+- path: File or directory path
+- password: Masked text input
+
+### Package Output Model
+
+**Generated Artifacts**:
+The tool produces three primary artifacts:
+
+**1. Debian Binary Package (.deb)**:
+Contains all installed files with metadata
+
+**2. Build Info File (.buildinfo)**:
+Build environment information for reproducibility
+
+**3. Changes File (.changes)**:
+Package changes and checksums
+
+**Package Contents Structure**:
+```
+/var/lib/container-apps/<package>/
+├── docker-compose.yml
+├── metadata.yaml
+├── config.yml
+└── env.template
+
+/etc/container-apps/<package>/
+├── env.defaults (updated on every install/upgrade)
+└── env (user overrides, created once on first install)
+
+/etc/systemd/system/
+└── <package>.service
+
+/usr/share/pixmaps/
+└── <package>.(svg|png) (if icon provided)
+
+/usr/share/metainfo/
+└── <package>.metainfo.xml (AppStream metadata)
+
+/usr/share/doc/<package>/
+├── copyright
+└── changelog.gz
+```
+
+## Technology Stack
+
+### Core Technologies
+
+**Python 3.9+**:
+- **Why**: Wide availability on target platforms, excellent library ecosystem
+- **Alternatives considered**: Bash (too complex), Go (packaging overhead), Rust (fewer dependencies available)
+- **Trade-offs**: Slower than compiled languages but sufficient for tool's use case
+
+**Jinja2**:
+- **Why**: Powerful, mature template engine with good error handling
+- **Alternatives considered**: String formatting (too limited), mako (less widely used)
+- **Trade-offs**: Dependency on external library but worth it for maintainability
+
+**Pydantic v2**:
+- **Why**: Type-safe validation using Python type hints, excellent error messages, fast (Rust-based core)
+- **Alternatives considered**: jsonschema (more verbose), custom validation (more code)
+- **Trade-offs**: None - Pydantic v2 is superior and available in Debian Trixie
+- **Benefits**: Can generate JSON schemas for documentation, validates parsed YAML directly
+
+**dpkg-buildpackage**:
+- **Why**: Standard Debian package building tool, handles complexity correctly
+- **Alternatives considered**: Custom package building (fragile), fpm (not standard)
+- **Trade-offs**: Requires full dpkg-dev toolchain but ensures correct packages
+
+### Python Libraries
+
+**Standard Library**:
+- argparse: CLI argument parsing
+- json: JSON parsing
+- pathlib: Path manipulation
+- subprocess: External command execution
+- logging: Structured logging
+- typing: Type hints for clarity
+
+**External Dependencies** (all in Debian Trixie):
+- python3-jinja2: Template rendering
+- python3-pydantic: Data validation with type hints
+- python3-yaml: YAML parsing
+
+### Development Tools
+
+**Package Management**:
+- uv: Fast Python package installer and resolver (replaces pip/pip-tools)
+
+**Testing**:
+- pytest: Test framework
+- pytest-cov: Coverage reporting
+
+**Code Quality**:
+- ruff: Fast Python linter and formatter (replaces flake8 and black)
+- ty: Fast Rust-based Python type checker (similar to mypy)
+- typos: Spell checker for code
+
+### Build Tools
+
+**Debian Packaging**:
+- dpkg-dev: Package building utilities
+- debhelper: Packaging helper scripts
+- lintian: Package quality checks
+
+## Integration Points
+
+### Input Integration
+
+**File System**:
+- Reads input files from specified directory
+- No network access required
+- Works offline
+
+**Validation**:
+- Self-contained validation using embedded schemas
+- No external validators or services
+
+### Output Integration
+
+**Package Repository**:
+- Generated packages compatible with any Debian APT repository
+- Can be uploaded to apt.hatlabs.fi or other repos
+- Signing happens externally (not tool's responsibility)
+
+**CI/CD Pipeline**:
+- Returns appropriate exit codes for automation
+- Structured output for parsing (with --json flag in future)
+- Reproducible builds (same input → same output)
+
+**Version Control**:
+- Input definitions stored in git repositories
+- Tool output (.deb files) typically not committed
+- Build artifacts generated on-demand or in CI
+
+### Runtime Integration
+
+**systemd**:
+- Generated service files integrate with systemd
+- Services depend on docker.service
+- Logging integrates with journald
+
+**Docker**:
+- Uses docker-compose command for container management
+- Assumes Docker installed on target system
+- No direct Docker API usage
+
+**APT Package Manager**:
+- Generated packages install via apt/dpkg
+- Dependencies resolved automatically
+- Configuration managed via debconf (future)
+
+## Deployment Architecture
+
+### Tool Distribution
+
+**Package Name**: container-packaging-tools
+
+**Installation**:
+```
+/usr/bin/
+└── generate-container-packages
+
+/usr/share/container-packaging-tools/
+├── templates/
+│   ├── debian/
+│   │   ├── control.j2
+│   │   ├── rules.j2
+│   │   ├── install.j2
+│   │   ├── postinst.j2
+│   │   ├── prerm.j2
+│   │   ├── postrm.j2
+│   │   ├── changelog.j2
+│   │   ├── copyright.j2
+│   │   └── compat
+│   └── systemd/
+│       └── service.j2
+└── schemas/
+    ├── metadata.py
+    └── config.py
+
+/usr/share/doc/container-packaging-tools/
+├── README.md
+├── EXAMPLES.md
+├── copyright
+└── changelog.gz
+```
+
+**Dependencies**:
+All dependencies are resolved by APT during installation:
+- Python runtime and libraries
+- Debian packaging tools
+- Docker (recommended for testing generated packages)
+
+### Execution Environment
+
+**Development**:
+- Developer workstations (macOS, Linux)
+- Docker containers for isolated testing
+- CI/CD runners (GitHub Actions)
+
+**Production**:
+- Build servers (dedicated or CI/CD)
+- Developer machines (ad-hoc package creation)
+- Automated pipelines (scheduled builds)
+
+**Target Deployment**:
+- Raspberry Pi 4/5 running Raspberry Pi OS (arm64)
+- Any Debian 12+ system (amd64, arm64)
+- Docker must be installed on target systems
+
+## Security Considerations
+
+### Input Validation
+
+**Threat**: Malicious input files could exploit validation or template rendering
+
+**Mitigation**:
+- Schema validation catches malformed input
+- No code execution from input files
+- File paths validated to prevent directory traversal
+- YAML safe loader used (no arbitrary code execution)
+
+### File System Access
+
+**Threat**: Tool might overwrite important files or access sensitive data
+
+**Mitigation**:
+- Tool only writes to specified output directory
+- No root privileges required for package generation
+- Generated packages follow standard Debian security practices
+- Maintainer scripts reviewed for security issues
+
+### Dependency Security
+
+**Threat**: Compromised dependencies could affect tool behavior
+
+**Mitigation**:
+- Only Debian stable dependencies (trusted, reviewed)
+- No external network dependencies
+- Minimal dependency surface area
+- Dependencies updated via Debian security process
+
+### Generated Package Security
+
+**Threat**: Generated packages might be insecure
+
+**Mitigation**:
+- Standard file permissions applied
+- No setuid/setgid binaries
+- Service runs as root (required for Docker) but follows best practices
+- User data in separate directories from application data
+- Configuration files not world-readable
+
+### Build Environment
+
+**Threat**: Build environment compromise could affect packages
+
+**Mitigation**:
+- Reproducible builds minimize attack surface
+- Build happens in isolated directory
+- Temporary files cleaned up properly
+- Build artifacts checksummed
+
+## Performance Considerations
+
+### Expected Performance
+
+**Typical Package Generation**:
+- Validation: < 1 second
+- Template rendering: < 1 second
+- Package building: 2-5 seconds
+- Total: < 10 seconds
+
+**Large Packages**:
+- With many screenshots/assets: < 20 seconds
+- Complex compose files: no significant impact
+
+### Optimization Strategies
+
+**I/O Optimization**:
+- Files loaded sequentially (small files, not a bottleneck)
+- Binary files copied efficiently
+- Temporary directory on fast storage
+
+**CPU Optimization**:
+- Single-threaded (sufficient for use case)
+- No CPU-intensive operations
+- Template rendering is fast for small templates
+
+**Memory Optimization**:
+- All input files fit in memory (typically < 1 MB)
+- No streaming required
+- Python garbage collection handles cleanup
+
+### Scalability
+
+**Concurrent Builds**:
+- Tool is stateless and safe for concurrent execution
+- Different output directories for parallel builds
+- No shared state between invocations
+
+**Batch Processing**:
+- Can process multiple apps in sequence or parallel
+- CI/CD can run multiple instances safely
+- No resource contention concerns
+
+## Extensibility and Future Enhancements
+
+### Extension Points
+
+**Custom Templates**:
+Future versions could support:
+- User-provided template overrides
+- Template includes and inheritance
+- Custom template functions
+
+**Plugin Architecture**:
+Potential plugin system for:
+- Custom validators
+- Alternative build backends
+- Post-processing hooks
+- Format converters
+
+**Configuration**:
+Future configuration file could specify:
+- Template directory overrides
+- Default values
+- Build options
+- Output formats
+
+### Phase 2+ Architecture Changes
+
+**AppStream Metadata**:
+- Add AppStream XML template
+- Generate desktop files for GUI apps
+- Include additional metadata fields
+
+**Multi-Architecture**:
+- Cross-compilation support
+- Architecture-specific templates
+- Multi-arch package generation
+
+**Package Signing**:
+- GPG integration for signing
+- Keyring management
+- Signature verification
+
+**Alternative Backends**:
+- Podman support as Docker alternative
+- containerd support
+- OCI bundle generation
+
+## Testing Strategy
+
+### Unit Testing
+
+**Component Tests**:
+- Validator: Test each validation rule independently
+- Loader: Test file parsing edge cases
+- Template Renderer: Test template logic
+- Path generator: Test path construction
+
+**Test Coverage Target**: >80%
+
+### Integration Testing
+
+**End-to-End Tests**:
+- Valid input → successful package
+- Invalid input → appropriate error
+- Generated package installs correctly
+- Service starts and stops properly
+- Package removes cleanly
+
+**Test Environments**:
+- Docker containers (Debian 12)
+- Raspberry Pi OS images
+- Multiple architecture emulation
+
+### Validation Testing
+
+**Schema Validation**:
+- Every schema rule has test case
+- Edge cases (min/max, boundaries)
+- Invalid format detection
+- Missing field detection
+
+### Package Testing
+
+**Generated Package Quality**:
+- Lintian checks pass
+- Files installed to correct locations
+- Permissions set correctly
+- Service unit is valid
+- Scripts execute without errors
+
+### Performance Testing
+
+**Benchmarks**:
+- Package generation time
+- Validation performance
+- Memory usage
+- Concurrent build handling
+
+## Error Handling Strategy
+
+### Error Categories
+
+**User Errors** (Exit 1):
+- Invalid input files
+- Schema violations
+- Missing required files
+Guidance: Clear message with correction suggestion
+
+**System Errors** (Exit 3):
+- Disk full
+- Permission denied
+- dpkg-buildpackage failure
+Guidance: System-level troubleshooting steps
+
+**Tool Errors** (Exit 2):
+- Template rendering failure
+- Internal logic errors
+Guidance: Bug report instructions
+
+**Dependency Errors** (Exit 4):
+- Missing system packages
+- Python import failures
+Guidance: Installation instructions
+
+### Error Message Format
+
+**Structure**:
+```
+ERROR: <Category>: <Problem>
+  File: <path>:<line>
+  Field: <field_name>
+  Current value: <value>
+  Expected: <expected_format>
+  Suggestion: <how_to_fix>
+```
+
+**Examples**:
+- Validation errors include file and line
+- Missing files show expected location
+- Build errors include dpkg output
+- Permission errors show required access
+
+## Monitoring and Observability
+
+### Logging
+
+**Log Levels**:
+- ERROR: Failures and fatal errors
+- WARNING: Potential issues
+- INFO: Major processing steps
+- DEBUG: Detailed execution trace
+
+**Log Output**:
+- Default: stderr (errors and warnings only)
+- Verbose: stdout (info messages)
+- Debug: stdout (all messages)
+
+### Metrics
+
+**Future Enhancements** (Phase 2+):
+- Build success/failure rates
+- Average build times
+- Common error types
+- Package generation statistics
+
+### Debugging
+
+**Debug Mode**:
+- Enable with --debug flag
+- Shows template rendering details
+- Preserves temporary build directory
+- Includes full stack traces
+
+**Troubleshooting**:
+- Validation mode for pre-flight checks
+- Dry-run mode for testing without building
+- Keep-temp flag for manual inspection
+
+## Documentation Strategy
+
+### User Documentation
+
+**README.md**:
+- Quick start guide
+- Installation instructions
+- Basic usage examples
+- Link to detailed docs
+
+**EXAMPLES.md**:
+- Complete working examples
+- Common use cases
+- Troubleshooting tips
+- Best practices
+
+**Man Page** (future):
+- Command reference
+- Option descriptions
+- Examples
+- See also section
+
+### Developer Documentation
+
+**Code Comments**:
+- Docstrings for all public functions
+- Inline comments for complex logic
+- Type hints throughout
+
+**Architecture Documentation**:
+- This document (ARCHITECTURE.md)
+- DESIGN.md for detailed designs
+- SPEC.md for requirements
+
+### Schema Documentation
+
+**Pydantic Models**:
+- Python docstrings for model classes
+- `Field` descriptions for each attribute
+- Examples provided via `Field`'s `example` parameter
+- Custom validators for complex validation logic
+
+## References
+
+### Internal Documentation
+
+- [SPEC.md](SPEC.md) - Technical specification
+- [DESIGN.md](DESIGN.md) - Detailed design
+- [META-PLANNING.md](../../META-PLANNING.md) - Project planning
+- [PROJECT_PLANNING_GUIDE.md](../../PROJECT_PLANNING_GUIDE.md) - Development workflow
+
+### External References
+
+- [Debian Policy Manual](https://www.debian.org/doc/debian-policy/) - Packaging standards
+- [debhelper Documentation](https://manpages.debian.org/testing/debhelper/debhelper.7.en.html) - Build helpers
+- [systemd Documentation](https://www.freedesktop.org/software/systemd/man/) - Service units
+- [Docker Compose Specification](https://docs.docker.com/compose/compose-file/) - Compose format
+- [Jinja2 Documentation](https://jinja.palletsprojects.com/) - Template engine
+- [JSON Schema](https://json-schema.org/) - Validation specification
+- [Pydantic Documentation](https://docs.pydantic.dev/) - Data validation and settings management
+
+## Document History
+
+- **2025-11-11**: Initial architecture document created for Phase 1 development

--- a/docs/PACKAGING_SPEC.md
+++ b/docs/PACKAGING_SPEC.md
@@ -1,0 +1,434 @@
+# Container Packaging Tools - Technical Specification
+
+**Status**: Draft
+**Version**: 1.0
+**Date**: 2025-11-11
+**Last Updated**: 2025-11-11
+
+## Document Purpose
+
+This specification defines the functional and technical requirements for the Container Packaging Tools project. It describes what the system must do and the constraints under which it must operate.
+
+## Project Overview
+
+### Summary
+
+Container Packaging Tools is a command-line utility that automates the generation of Debian packages from container application definitions. It transforms simple declarative definitions (metadata, Docker Compose files, and configuration schemas) into fully functional Debian packages with systemd integration.
+
+### Goals
+
+1. **Standardization**: Establish a consistent, repeatable process for packaging container applications as Debian packages
+2. **Automation**: Eliminate manual package creation work and reduce human error
+3. **Integration**: Seamlessly integrate with HaLOS ecosystem and Cockpit-based management
+4. **Quality**: Ensure generated packages meet Debian policy and quality standards
+5. **Usability**: Provide clear error messages and validation feedback to package creators
+
+### Target Users
+
+- **HaLOS Developers**: Creating marine and system container applications
+- **Third-Party Developers**: Contributing apps to HaLOS stores
+- **Package Maintainers**: Managing container app packages in APT repositories
+- **CI/CD Systems**: Automated package generation in build pipelines
+
+## Core Features
+
+### Package Generation
+
+The tool must accept a directory containing application definition files and produce a valid Debian binary package. The generated package must include:
+
+- Standard Debian package metadata (control file, changelog, copyright)
+- systemd service unit for container lifecycle management
+- Pre- and post-installation scripts for proper system integration
+- Application files in standard locations
+- User configuration files with sensible defaults
+
+### Input Validation
+
+The tool must validate all input files before attempting package generation:
+
+- **Metadata Validation**: Verify JSON schema compliance, required fields, format constraints
+- **Docker Compose Validation**: Check YAML syntax, Docker Compose schema version, environment variable usage
+- **Configuration Schema Validation**: Validate field definitions, types, and constraints
+- **Cross-Validation**: Ensure consistency between metadata, compose file, and configuration
+- **File Checks**: Verify required files exist and optional files meet format requirements
+
+Validation errors must be clear, actionable, and include suggested fixes where possible.
+
+### Template System
+
+The tool must use a flexible template system for generating package files. Templates must:
+
+- Support variable substitution based on application metadata
+- Handle optional fields gracefully
+- Generate syntactically correct output files
+- Be maintainable and customizable
+- Support both simple and complex package scenarios
+
+### Error Handling
+
+The tool must provide clear error reporting for:
+
+- Missing or invalid input files
+- Schema validation failures
+- Template rendering errors
+- Build process failures
+- System dependency issues
+
+Error messages must include file paths, line numbers where applicable, specific error descriptions, and suggested remediation steps.
+
+## Functional Requirements
+
+### FR1: Command-Line Interface
+
+The tool must provide a command-line interface with the following capabilities:
+
+- Accept input directory path as primary argument
+- Support output directory specification
+- Provide validation-only mode (no package generation)
+- Offer multiple verbosity levels (quiet, normal, verbose, debug)
+- Display version information
+- Show usage help
+
+### FR2: Input File Processing
+
+The tool must process three required input files:
+
+1. **metadata.yaml**: Package metadata including name, version, description, maintainer, dependencies, and tags
+2. **docker-compose.yml**: Docker Compose configuration defining container services, volumes, and networks
+3. **config.yml**: User-configurable parameters organized into groups with typed fields
+
+Optional input files include application icons, screenshots, and additional documentation.
+
+### FR3: Package Structure Generation
+
+The tool must generate a complete Debian source package structure including:
+
+- debian/control: Package metadata and dependencies
+- debian/rules: Build rules following debhelper conventions
+- debian/install: File installation mappings
+- debian/postinst: Post-installation script for service setup
+- debian/prerm: Pre-removal script for service shutdown
+- debian/postrm: Post-removal script for cleanup
+- debian/changelog: Package changelog in Debian format
+- debian/copyright: Copyright and license information
+- debian/compat: Debhelper compatibility level
+- debian/*.service: systemd service unit file
+
+### FR4: Path Standardization
+
+The tool must enforce standard installation paths:
+
+- Application files: `/var/lib/container-apps/<package-name>/`
+- Configuration files: `/etc/container-apps/<package-name>/`
+- systemd service: `/etc/systemd/system/<package-name>.service`
+- Application icon: `/usr/share/pixmaps/<package-name>.(svg|png)` (SVG preferred)
+- Documentation: `/usr/share/doc/<package-name>/`
+
+### FR5: systemd Integration
+
+The tool must generate systemd service units that:
+
+- Start containers using docker-compose
+- Stop containers gracefully on service stop
+- Load environment variables from configuration files
+- Set proper working directories
+- Depend on Docker service availability
+- Enable automatic startup on boot
+- Integrate with systemd logging (journald)
+
+### FR6: Configuration Management
+
+The tool must handle configuration through:
+
+- Environment variable templates generated from metadata defaults
+- Configuration files created during package installation
+- Preservation of user configuration during package upgrades
+- Removal options (keep or purge) during package removal
+
+### FR7: Package Building
+
+The tool must invoke dpkg-buildpackage to create binary packages:
+
+- Generate unsigned binary-only packages by default
+- Produce standard Debian package artifacts (.deb, .buildinfo, .changes)
+- Handle build errors gracefully with clear error messages
+- Support build directory cleanup or preservation for debugging
+
+### FR8: Package Naming Conventions
+
+The tool must enforce naming conventions:
+
+- Package names must end with `-container` suffix
+- Package names must use lowercase with hyphens
+- Version numbers must be valid Debian versions (supports semver, date-based, CalVer, hybrid schemes)
+- Filenames must follow Debian standards
+
+**Supported Version Formats**:
+
+The tool supports any versioning scheme compatible with Debian package versioning. Common patterns include:
+
+- **Semantic Versioning (semver)**: `1.2.3`, `2.8.0-1` (with Debian revision)
+  - Used by Signal K, OpenCPN, and many modern applications
+- **Date-based**: `20250113`, `20250113-1` (YYYYMMDD format)
+  - Used by AvNav and applications with frequent time-based releases
+- **Calendar Versioning (CalVer)**: `2025.01.13`, `2025.1-1`
+  - Alternative date-based format with better human readability
+- **Hybrid schemes**: `5.8.4+git20250113`, `3.2.1~rc1`
+  - Combines base version with additional metadata (git date, release candidate, etc.)
+- **Epoch versioning**: `1:2.8.0` (for handling version scheme changes)
+
+Version validation uses `dpkg --compare-versions` to ensure compatibility with Debian's version comparison algorithm.
+
+### FR9: Tagging and Categorization
+
+The tool must support Debian tags (debtags) for package categorization:
+
+- Require `role::container-app` tag for all packages
+- Support additional field tags (e.g., `field::marine`, `field::home-automation`)
+- Validate tag format and known tag names
+- Generate tag entries in package control file
+
+### FR10: AppStream Metadata Generation
+
+The tool must generate AppStream metadata for software center integration:
+
+- Create AppStream XML file from package metadata
+- Include application name, summary, description, icon, screenshots
+- Support categorization with AppStream categories
+- Install to `/usr/share/metainfo/` for GNOME Software, KDE Discover integration
+- Validate generated XML against AppStream specification
+- Enable discovery in software centers beyond Cockpit
+
+## Technical Requirements
+
+### TR1: Programming Language and Runtime
+
+The tool must be implemented in Python 3.11 or later for:
+
+- Wide availability on Debian Bookworm (Stable) and later systems
+- Strong typing support including modern union types (X | Y syntax)
+- Rich ecosystem of libraries for YAML, JSON, templating
+- Ease of maintenance and contribution
+- Good error handling and reporting capabilities
+
+### TR2: Dependencies
+
+The tool must depend only on packages available in Debian Bookworm (Stable) and later:
+
+- python3 (>= 3.11)
+- python3-jinja2 (templating)
+- python3-pydantic (>= 2.0) (validation with type hints)
+- python3-yaml (YAML parsing)
+- dpkg-dev (package building tools)
+- debhelper (>= 12)
+
+No external dependencies outside Debian repositories are permitted.
+
+### TR3: Distribution Package
+
+The tool itself must be distributed as a Debian package:
+
+- Package name: `container-packaging-tools`
+- Install executable to `/usr/bin/`
+- Install templates to `/usr/share/container-packaging-tools/templates/`
+- Install schemas to `/usr/share/container-packaging-tools/schemas/`
+- Install documentation to `/usr/share/doc/container-packaging-tools/`
+- Follow Debian packaging standards and policies
+
+### TR4: File Formats
+
+The tool must support standard file formats:
+
+- YAML for all configuration files (YAML 1.2)
+- SVG or PNG for application icons (SVG preferred for scalability)
+- PNG for screenshots
+- Markdown for documentation
+- Plain text for logs and error messages
+
+### TR5: Data Validation
+
+The tool must use Pydantic for validation:
+
+- Define Pydantic models for metadata.yaml and config.yml structures
+- Validate required fields, data types, format constraints using type hints
+- Provide clear, actionable validation error messages
+- Support model versioning for future extensions
+- Validate parsed YAML data directly with type safety
+- Can export JSON schemas for documentation purposes
+
+### TR6: Template Engine
+
+The tool must use Jinja2 for template rendering:
+
+- Support variable substitution and expressions
+- Handle optional fields with conditional blocks
+- Format multi-line text appropriately for Debian control files
+- Generate syntactically correct output
+
+### TR7: Debian Compatibility
+
+Generated packages must be compatible with:
+
+- Debian 12 (bookworm) and later
+- Raspberry Pi OS 64-bit (based on Debian)
+- Standard Debian packaging tools (dpkg, apt)
+- Debian Policy Manual version 4.5.0 or later
+
+### TR8: Docker Compose Compatibility
+
+The tool must support Docker Compose file format version 3.8 or later, including:
+
+- Service definitions with images and build contexts
+- Bind mounts for data persistence (preferred over named volumes)
+- Environment variable substitution
+- Port mappings
+- Network definitions
+- No restart policies (lifecycle managed by systemd)
+
+## Non-Functional Requirements
+
+### NFR1: Performance
+
+- Package generation must complete in under 10 seconds for typical applications
+- Validation-only mode must complete in under 2 seconds
+- Memory usage must not exceed 100 MB during normal operation
+- Support concurrent execution for batch processing
+
+### NFR2: Reliability
+
+- Validation must catch all schema violations before package building
+- Build failures must not leave partial artifacts in output directory
+- Error handling must be comprehensive with no uncaught exceptions
+- Generated packages must install and remove cleanly
+
+### NFR3: Usability
+
+- Command-line interface must follow Unix conventions
+- Error messages must be clear and actionable
+- Help text must be comprehensive and include examples
+- Validation feedback must guide users to correct problems
+- Exit codes must indicate specific error categories
+
+### NFR4: Maintainability
+
+- Code must follow Python PEP 8 style guidelines
+- Functions must be modular with clear responsibilities
+- Templates must be separate from code logic
+- Schemas must be external and versionable
+- Comments must explain complex logic and edge cases
+
+### NFR5: Testability
+
+- Core functions must be unit testable
+- Integration tests must verify complete package generation
+- Test fixtures must cover valid and invalid inputs
+- Tests must run in CI/CD environments
+- Generated packages must be installable in test containers
+
+### NFR6: Security
+
+- Validation must prevent path traversal attacks
+- File permissions must be set appropriately
+- No execution of arbitrary code from input files
+- Package scripts must follow security best practices
+- Dependencies must be from trusted repositories only
+
+### NFR7: Documentation
+
+- CLI help must document all options and arguments
+- README must provide quick start guide and examples
+- EXAMPLES.md must show common use cases
+- Schema documentation must explain all fields
+- Generated packages must include proper documentation
+
+### NFR8: Extensibility
+
+- Template system must allow customization
+- Schema validation must support custom fields
+- Architecture must accommodate future enhancements
+- Plugin system considerations for Phase 2+
+
+## Constraints and Assumptions
+
+### Constraints
+
+1. **Platform**: Must run on Debian-based ARM64 systems (Raspberry Pi 4/5)
+2. **Dependencies**: Only Debian stable repository packages permitted
+3. **Docker**: Assumes Docker is installed and available on target systems
+4. **Permissions**: Package installation requires root/sudo access
+5. **systemd**: Target systems must use systemd as init system
+6. **Network**: No network access required during package generation (offline capable)
+
+### Assumptions
+
+1. Input files are created by humans or trusted tools, not arbitrary user input
+2. Docker Compose files reference published container images or local builds
+3. Users have basic knowledge of Debian packaging concepts
+4. Target systems have sufficient disk space for container images and volumes
+5. Container applications expose configuration through environment variables
+6. Application maintainers will keep metadata and compose files synchronized
+
+## Out of Scope
+
+The following features are explicitly out of scope for Phase 1:
+
+### Not Included in Phase 1
+
+1. **GUI Interface**: No graphical configuration wizard (command-line only)
+2. **Repository Publishing**: No automatic upload to APT repositories
+3. **Package Signing**: No GPG signing support
+4. **Multi-Architecture Builds**: No cross-compilation support
+5. **Conversion Tools**: No import from other app store formats
+6. **Container Validation**: No runtime testing of container functionality
+7. **Image Building**: No Docker image building, only references to existing images
+8. **Alternative Runtimes**: Docker Compose only, no podman or containerd support
+9. **Custom Templates**: No user-customizable template system
+
+## Success Criteria
+
+The Container Packaging Tools project will be considered successful when:
+
+1. **Functional Completeness**: All core features are implemented and working
+2. **Quality**: Generated packages install cleanly and services start reliably
+3. **Usability**: Developers can create packages without reading extensive documentation
+4. **Integration**: Tool integrates smoothly into HaLOS development workflow
+5. **Validation**: At least 5 real applications successfully packaged using the tool
+6. **Documentation**: Complete usage documentation with examples
+7. **Testing**: Comprehensive test suite with >80% code coverage
+8. **Acceptance**: Tool is used for all marine container app packaging in Phase 1
+
+## Acceptance Testing
+
+### Test Cases
+
+1. **TC1**: Generate package from minimal valid input (metadata, compose, config)
+2. **TC2**: Validate detection of missing required files
+3. **TC3**: Validate detection of schema violations in metadata
+4. **TC4**: Validate detection of invalid Docker Compose syntax
+5. **TC5**: Install generated package on clean Debian system
+6. **TC6**: Verify systemd service starts and runs container
+7. **TC7**: Verify configuration file creation and environment variable loading
+8. **TC8**: Remove package and verify cleanup (config preserved)
+9. **TC9**: Purge package and verify complete removal (config deleted)
+10. **TC10**: Generate 5 real marine applications successfully
+
+## References
+
+### Internal Documentation
+
+- [DESIGN.md](DESIGN.md) - Detailed design specifications
+- [META-PLANNING.md](../../META-PLANNING.md) - Overall project planning
+- [PROJECT_PLANNING_GUIDE.md](../../PROJECT_PLANNING_GUIDE.md) - Development workflow
+
+### External Standards
+
+- [Debian Policy Manual](https://www.debian.org/doc/debian-policy/) - Debian packaging standards
+- [Debian New Maintainers' Guide](https://www.debian.org/doc/manuals/maint-guide/) - Package creation guide
+- [Docker Compose Specification](https://docs.docker.com/compose/compose-file/) - Compose file format
+- [JSON Schema Specification](https://json-schema.org/) - Schema validation standard
+- [systemd Service Units](https://www.freedesktop.org/software/systemd/man/systemd.service.html) - Service file format
+- [Semantic Versioning](https://semver.org/) - Version numbering specification
+
+## Document History
+
+- **2025-11-11**: Initial specification created for Phase 1 development

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,434 +1,82 @@
-# Container Packaging Tools - Technical Specification
+# Container Packaging Tools - Technical Specifications
 
-**Status**: Draft
 **Version**: 1.0
-**Date**: 2025-11-11
-**Last Updated**: 2025-11-11
+**Date**: 2025-11-26
+**Status**: Active
 
-## Document Purpose
+## Overview
 
-This specification defines the functional and technical requirements for the Container Packaging Tools project. It describes what the system must do and the constraints under which it must operate.
+This document serves as the index to all technical specifications for the Container Packaging Tools project. The project consists of multiple components with distinct functionality, each documented in its own specification.
 
-## Project Overview
+## Project Purpose
 
-### Summary
+Container Packaging Tools automates the creation of Debian packages for containerized applications. It transforms simple declarative definitions into complete Debian packages with systemd integration, enabling easy distribution and management of container apps through standard APT package management.
 
-Container Packaging Tools is a command-line utility that automates the generation of Debian packages from container application definitions. It transforms simple declarative definitions (metadata, Docker Compose files, and configuration schemas) into fully functional Debian packages with systemd integration.
+## Components
 
-### Goals
+The project consists of two main functional areas:
 
-1. **Standardization**: Establish a consistent, repeatable process for packaging container applications as Debian packages
-2. **Automation**: Eliminate manual package creation work and reduce human error
-3. **Integration**: Seamlessly integrate with HaLOS ecosystem and Cockpit-based management
-4. **Quality**: Ensure generated packages meet Debian policy and quality standards
-5. **Usability**: Provide clear error messages and validation feedback to package creators
+### 1. Core Package Generation
 
-### Target Users
+The core packaging system converts application definitions (metadata.yaml, config.yml, docker-compose.yml) into Debian packages.
 
-- **HaLOS Developers**: Creating marine and system container applications
-- **Third-Party Developers**: Contributing apps to HaLOS stores
-- **Package Maintainers**: Managing container app packages in APT repositories
-- **CI/CD Systems**: Automated package generation in build pipelines
+**📄 [Package Generation Specification](PACKAGING_SPEC.md)**
 
-## Core Features
+This specification covers:
+- Input format requirements (metadata, compose, config)
+- Package generation process
+- Debian package structure
+- systemd service integration
+- Validation and error handling
+- Template system
+- Installation and upgrade behavior
 
-### Package Generation
+### 2. CasaOS Converter
 
-The tool must accept a directory containing application definition files and produce a valid Debian binary package. The generated package must include:
+The CasaOS converter transforms applications from the CasaOS app store format into the HaLOS container store format, enabling rapid catalog population.
 
-- Standard Debian package metadata (control file, changelog, copyright)
-- systemd service unit for container lifecycle management
-- Pre- and post-installation scripts for proper system integration
-- Application files in standard locations
-- User configuration files with sensible defaults
+**📄 [CasaOS Converter Specification](CONVERTER_SPEC.md)**
 
-### Input Validation
+This specification covers:
+- CasaOS format parsing
+- Metadata transformation
+- Category and field type mapping
+- Asset downloading (icons, screenshots)
+- Update synchronization with upstream
+- Batch conversion capabilities
 
-The tool must validate all input files before attempting package generation:
+## Document Organization
 
-- **Metadata Validation**: Verify JSON schema compliance, required fields, format constraints
-- **Docker Compose Validation**: Check YAML syntax, Docker Compose schema version, environment variable usage
-- **Configuration Schema Validation**: Validate field definitions, types, and constraints
-- **Cross-Validation**: Ensure consistency between metadata, compose file, and configuration
-- **File Checks**: Verify required files exist and optional files meet format requirements
+Each component has two primary documents:
 
-Validation errors must be clear, actionable, and include suggested fixes where possible.
+- **SPEC.md** (Specification): What the system must do - requirements, features, constraints
+- **ARCHITECTURE.md** (Architecture): How the system works - components, data flow, design decisions
 
-### Template System
+## Navigation
 
-The tool must use a flexible template system for generating package files. Templates must:
+- **[Main Architecture Document](ARCHITECTURE.md)**: System architecture index
+- **[Package Generation Specification](PACKAGING_SPEC.md)**: Core tool requirements
+- **[Package Generation Architecture](PACKAGING_ARCHITECTURE.md)**: Core tool design
+- **[CasaOS Converter Specification](CONVERTER_SPEC.md)**: Converter requirements
+- **[CasaOS Converter Architecture](CONVERTER_ARCHITECTURE.md)**: Converter design
+- **[Design Document](DESIGN.md)**: Overall design and planning
+- **[Security](SECURITY.md)**: Security considerations
 
-- Support variable substitution based on application metadata
-- Handle optional fields gracefully
-- Generate syntactically correct output files
-- Be maintainable and customizable
-- Support both simple and complex package scenarios
+## Development Process
 
-### Error Handling
+These specifications follow the [HaLOS Project Planning Guide](../../docs/PROJECT_PLANNING_GUIDE.md):
 
-The tool must provide clear error reporting for:
+1. Specifications are created before implementation begins
+2. Each spec requires review and approval before moving to architecture
+3. Architecture documents are created after spec approval
+4. Implementation follows documented specifications and architecture
 
-- Missing or invalid input files
-- Schema validation failures
-- Template rendering errors
-- Build process failures
-- System dependency issues
+## Versioning
 
-Error messages must include file paths, line numbers where applicable, specific error descriptions, and suggested remediation steps.
+Component specifications are versioned independently. Major changes to functionality require spec updates and review.
 
-## Functional Requirements
+---
 
-### FR1: Command-Line Interface
-
-The tool must provide a command-line interface with the following capabilities:
-
-- Accept input directory path as primary argument
-- Support output directory specification
-- Provide validation-only mode (no package generation)
-- Offer multiple verbosity levels (quiet, normal, verbose, debug)
-- Display version information
-- Show usage help
-
-### FR2: Input File Processing
-
-The tool must process three required input files:
-
-1. **metadata.yaml**: Package metadata including name, version, description, maintainer, dependencies, and tags
-2. **docker-compose.yml**: Docker Compose configuration defining container services, volumes, and networks
-3. **config.yml**: User-configurable parameters organized into groups with typed fields
-
-Optional input files include application icons, screenshots, and additional documentation.
-
-### FR3: Package Structure Generation
-
-The tool must generate a complete Debian source package structure including:
-
-- debian/control: Package metadata and dependencies
-- debian/rules: Build rules following debhelper conventions
-- debian/install: File installation mappings
-- debian/postinst: Post-installation script for service setup
-- debian/prerm: Pre-removal script for service shutdown
-- debian/postrm: Post-removal script for cleanup
-- debian/changelog: Package changelog in Debian format
-- debian/copyright: Copyright and license information
-- debian/compat: Debhelper compatibility level
-- debian/*.service: systemd service unit file
-
-### FR4: Path Standardization
-
-The tool must enforce standard installation paths:
-
-- Application files: `/var/lib/container-apps/<package-name>/`
-- Configuration files: `/etc/container-apps/<package-name>/`
-- systemd service: `/etc/systemd/system/<package-name>.service`
-- Application icon: `/usr/share/pixmaps/<package-name>.(svg|png)` (SVG preferred)
-- Documentation: `/usr/share/doc/<package-name>/`
-
-### FR5: systemd Integration
-
-The tool must generate systemd service units that:
-
-- Start containers using docker-compose
-- Stop containers gracefully on service stop
-- Load environment variables from configuration files
-- Set proper working directories
-- Depend on Docker service availability
-- Enable automatic startup on boot
-- Integrate with systemd logging (journald)
-
-### FR6: Configuration Management
-
-The tool must handle configuration through:
-
-- Environment variable templates generated from metadata defaults
-- Configuration files created during package installation
-- Preservation of user configuration during package upgrades
-- Removal options (keep or purge) during package removal
-
-### FR7: Package Building
-
-The tool must invoke dpkg-buildpackage to create binary packages:
-
-- Generate unsigned binary-only packages by default
-- Produce standard Debian package artifacts (.deb, .buildinfo, .changes)
-- Handle build errors gracefully with clear error messages
-- Support build directory cleanup or preservation for debugging
-
-### FR8: Package Naming Conventions
-
-The tool must enforce naming conventions:
-
-- Package names must end with `-container` suffix
-- Package names must use lowercase with hyphens
-- Version numbers must be valid Debian versions (supports semver, date-based, CalVer, hybrid schemes)
-- Filenames must follow Debian standards
-
-**Supported Version Formats**:
-
-The tool supports any versioning scheme compatible with Debian package versioning. Common patterns include:
-
-- **Semantic Versioning (semver)**: `1.2.3`, `2.8.0-1` (with Debian revision)
-  - Used by Signal K, OpenCPN, and many modern applications
-- **Date-based**: `20250113`, `20250113-1` (YYYYMMDD format)
-  - Used by AvNav and applications with frequent time-based releases
-- **Calendar Versioning (CalVer)**: `2025.01.13`, `2025.1-1`
-  - Alternative date-based format with better human readability
-- **Hybrid schemes**: `5.8.4+git20250113`, `3.2.1~rc1`
-  - Combines base version with additional metadata (git date, release candidate, etc.)
-- **Epoch versioning**: `1:2.8.0` (for handling version scheme changes)
-
-Version validation uses `dpkg --compare-versions` to ensure compatibility with Debian's version comparison algorithm.
-
-### FR9: Tagging and Categorization
-
-The tool must support Debian tags (debtags) for package categorization:
-
-- Require `role::container-app` tag for all packages
-- Support additional field tags (e.g., `field::marine`, `field::home-automation`)
-- Validate tag format and known tag names
-- Generate tag entries in package control file
-
-### FR10: AppStream Metadata Generation
-
-The tool must generate AppStream metadata for software center integration:
-
-- Create AppStream XML file from package metadata
-- Include application name, summary, description, icon, screenshots
-- Support categorization with AppStream categories
-- Install to `/usr/share/metainfo/` for GNOME Software, KDE Discover integration
-- Validate generated XML against AppStream specification
-- Enable discovery in software centers beyond Cockpit
-
-## Technical Requirements
-
-### TR1: Programming Language and Runtime
-
-The tool must be implemented in Python 3.11 or later for:
-
-- Wide availability on Debian Bookworm (Stable) and later systems
-- Strong typing support including modern union types (X | Y syntax)
-- Rich ecosystem of libraries for YAML, JSON, templating
-- Ease of maintenance and contribution
-- Good error handling and reporting capabilities
-
-### TR2: Dependencies
-
-The tool must depend only on packages available in Debian Bookworm (Stable) and later:
-
-- python3 (>= 3.11)
-- python3-jinja2 (templating)
-- python3-pydantic (>= 2.0) (validation with type hints)
-- python3-yaml (YAML parsing)
-- dpkg-dev (package building tools)
-- debhelper (>= 12)
-
-No external dependencies outside Debian repositories are permitted.
-
-### TR3: Distribution Package
-
-The tool itself must be distributed as a Debian package:
-
-- Package name: `container-packaging-tools`
-- Install executable to `/usr/bin/`
-- Install templates to `/usr/share/container-packaging-tools/templates/`
-- Install schemas to `/usr/share/container-packaging-tools/schemas/`
-- Install documentation to `/usr/share/doc/container-packaging-tools/`
-- Follow Debian packaging standards and policies
-
-### TR4: File Formats
-
-The tool must support standard file formats:
-
-- YAML for all configuration files (YAML 1.2)
-- SVG or PNG for application icons (SVG preferred for scalability)
-- PNG for screenshots
-- Markdown for documentation
-- Plain text for logs and error messages
-
-### TR5: Data Validation
-
-The tool must use Pydantic for validation:
-
-- Define Pydantic models for metadata.yaml and config.yml structures
-- Validate required fields, data types, format constraints using type hints
-- Provide clear, actionable validation error messages
-- Support model versioning for future extensions
-- Validate parsed YAML data directly with type safety
-- Can export JSON schemas for documentation purposes
-
-### TR6: Template Engine
-
-The tool must use Jinja2 for template rendering:
-
-- Support variable substitution and expressions
-- Handle optional fields with conditional blocks
-- Format multi-line text appropriately for Debian control files
-- Generate syntactically correct output
-
-### TR7: Debian Compatibility
-
-Generated packages must be compatible with:
-
-- Debian 12 (bookworm) and later
-- Raspberry Pi OS 64-bit (based on Debian)
-- Standard Debian packaging tools (dpkg, apt)
-- Debian Policy Manual version 4.5.0 or later
-
-### TR8: Docker Compose Compatibility
-
-The tool must support Docker Compose file format version 3.8 or later, including:
-
-- Service definitions with images and build contexts
-- Bind mounts for data persistence (preferred over named volumes)
-- Environment variable substitution
-- Port mappings
-- Network definitions
-- No restart policies (lifecycle managed by systemd)
-
-## Non-Functional Requirements
-
-### NFR1: Performance
-
-- Package generation must complete in under 10 seconds for typical applications
-- Validation-only mode must complete in under 2 seconds
-- Memory usage must not exceed 100 MB during normal operation
-- Support concurrent execution for batch processing
-
-### NFR2: Reliability
-
-- Validation must catch all schema violations before package building
-- Build failures must not leave partial artifacts in output directory
-- Error handling must be comprehensive with no uncaught exceptions
-- Generated packages must install and remove cleanly
-
-### NFR3: Usability
-
-- Command-line interface must follow Unix conventions
-- Error messages must be clear and actionable
-- Help text must be comprehensive and include examples
-- Validation feedback must guide users to correct problems
-- Exit codes must indicate specific error categories
-
-### NFR4: Maintainability
-
-- Code must follow Python PEP 8 style guidelines
-- Functions must be modular with clear responsibilities
-- Templates must be separate from code logic
-- Schemas must be external and versionable
-- Comments must explain complex logic and edge cases
-
-### NFR5: Testability
-
-- Core functions must be unit testable
-- Integration tests must verify complete package generation
-- Test fixtures must cover valid and invalid inputs
-- Tests must run in CI/CD environments
-- Generated packages must be installable in test containers
-
-### NFR6: Security
-
-- Validation must prevent path traversal attacks
-- File permissions must be set appropriately
-- No execution of arbitrary code from input files
-- Package scripts must follow security best practices
-- Dependencies must be from trusted repositories only
-
-### NFR7: Documentation
-
-- CLI help must document all options and arguments
-- README must provide quick start guide and examples
-- EXAMPLES.md must show common use cases
-- Schema documentation must explain all fields
-- Generated packages must include proper documentation
-
-### NFR8: Extensibility
-
-- Template system must allow customization
-- Schema validation must support custom fields
-- Architecture must accommodate future enhancements
-- Plugin system considerations for Phase 2+
-
-## Constraints and Assumptions
-
-### Constraints
-
-1. **Platform**: Must run on Debian-based ARM64 systems (Raspberry Pi 4/5)
-2. **Dependencies**: Only Debian stable repository packages permitted
-3. **Docker**: Assumes Docker is installed and available on target systems
-4. **Permissions**: Package installation requires root/sudo access
-5. **systemd**: Target systems must use systemd as init system
-6. **Network**: No network access required during package generation (offline capable)
-
-### Assumptions
-
-1. Input files are created by humans or trusted tools, not arbitrary user input
-2. Docker Compose files reference published container images or local builds
-3. Users have basic knowledge of Debian packaging concepts
-4. Target systems have sufficient disk space for container images and volumes
-5. Container applications expose configuration through environment variables
-6. Application maintainers will keep metadata and compose files synchronized
-
-## Out of Scope
-
-The following features are explicitly out of scope for Phase 1:
-
-### Not Included in Phase 1
-
-1. **GUI Interface**: No graphical configuration wizard (command-line only)
-2. **Repository Publishing**: No automatic upload to APT repositories
-3. **Package Signing**: No GPG signing support
-4. **Multi-Architecture Builds**: No cross-compilation support
-5. **Conversion Tools**: No import from other app store formats
-6. **Container Validation**: No runtime testing of container functionality
-7. **Image Building**: No Docker image building, only references to existing images
-8. **Alternative Runtimes**: Docker Compose only, no podman or containerd support
-9. **Custom Templates**: No user-customizable template system
-
-## Success Criteria
-
-The Container Packaging Tools project will be considered successful when:
-
-1. **Functional Completeness**: All core features are implemented and working
-2. **Quality**: Generated packages install cleanly and services start reliably
-3. **Usability**: Developers can create packages without reading extensive documentation
-4. **Integration**: Tool integrates smoothly into HaLOS development workflow
-5. **Validation**: At least 5 real applications successfully packaged using the tool
-6. **Documentation**: Complete usage documentation with examples
-7. **Testing**: Comprehensive test suite with >80% code coverage
-8. **Acceptance**: Tool is used for all marine container app packaging in Phase 1
-
-## Acceptance Testing
-
-### Test Cases
-
-1. **TC1**: Generate package from minimal valid input (metadata, compose, config)
-2. **TC2**: Validate detection of missing required files
-3. **TC3**: Validate detection of schema violations in metadata
-4. **TC4**: Validate detection of invalid Docker Compose syntax
-5. **TC5**: Install generated package on clean Debian system
-6. **TC6**: Verify systemd service starts and runs container
-7. **TC7**: Verify configuration file creation and environment variable loading
-8. **TC8**: Remove package and verify cleanup (config preserved)
-9. **TC9**: Purge package and verify complete removal (config deleted)
-10. **TC10**: Generate 5 real marine applications successfully
-
-## References
-
-### Internal Documentation
-
-- [DESIGN.md](DESIGN.md) - Detailed design specifications
-- [META-PLANNING.md](../../META-PLANNING.md) - Overall project planning
-- [PROJECT_PLANNING_GUIDE.md](../../PROJECT_PLANNING_GUIDE.md) - Development workflow
-
-### External Standards
-
-- [Debian Policy Manual](https://www.debian.org/doc/debian-policy/) - Debian packaging standards
-- [Debian New Maintainers' Guide](https://www.debian.org/doc/manuals/maint-guide/) - Package creation guide
-- [Docker Compose Specification](https://docs.docker.com/compose/compose-file/) - Compose file format
-- [JSON Schema Specification](https://json-schema.org/) - Schema validation standard
-- [systemd Service Units](https://www.freedesktop.org/software/systemd/man/systemd.service.html) - Service file format
-- [Semantic Versioning](https://semver.org/) - Version numbering specification
-
-## Document History
-
-- **2025-11-11**: Initial specification created for Phase 1 development
+**Current Component Versions:**
+- Core Package Generation: v1.0
+- CasaOS Converter: v1.0 (Draft)


### PR DESCRIPTION
## Summary

Reorganizes the documentation structure and adds comprehensive planning for the CasaOS converter feature.

## Documentation Restructuring

**Index Documents:**
- `docs/SPEC.md` - Now serves as index to all specifications
- `docs/ARCHITECTURE.md` - Now serves as index to all architecture docs

**Component-Specific Documents:**
- `docs/PACKAGING_SPEC.md` - Core tool specification (moved from SPEC.md)
- `docs/PACKAGING_ARCHITECTURE.md` - Core tool architecture (moved from ARCHITECTURE.md)
- `docs/CONVERTER_SPEC.md` - **NEW**: CasaOS converter specification
- `docs/CONVERTER_ARCHITECTURE.md` - **NEW**: CasaOS converter architecture

This structure provides clear navigation and separation of concerns as the project grows.

## CasaOS Converter Planning

Comprehensive planning documents for converting CasaOS app store definitions to HaLOS format.

### Key Features

- Parse CasaOS docker-compose.yml with x-casaos metadata extensions
- Transform metadata with configurable category mapping and field type inference
- Download and cache icons/screenshots from URLs
- Generate HaLOS format: metadata.yaml, config.yml, docker-compose.yml
- Batch conversion with parallel processing
- Update detection and upstream synchronization
- Package naming: `casaos-<app>-container` for clear provenance

### Implementation Approach

- **TDD Workflow**: All components follow Test-Driven Development
- **13 GitHub Issues**: Created (#81-92) with detailed implementation checklists
- **Integration**: Extends existing container-packaging-tools CLI and pipeline
- **Extensibility**: Base converter interface supports future sources (Runtipi, etc.)

### Benefits

- Rapidly populate HaLOS app catalog with hundreds of applications
- Clear source attribution prevents naming conflicts
- Automated updates keep catalog current with upstream
- Reuses core packaging infrastructure

## Documentation Navigation

All specs follow the [HaLOS Project Planning Guide](../../docs/PROJECT_PLANNING_GUIDE.md):
1. Specifications define requirements (WHAT)
2. Architecture documents define design (HOW)
3. Implementation tracked via GitHub issues

---

**Related Issues:** Planning creates foundation for #81-92

🤖 Generated with [Claude Code](https://claude.com/claude-code)