### PR TITLE
fix(build): add missing Debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,9 @@ Build-Depends: debhelper-compat (= 13),
  pybuild-plugin-pyproject,
  python3-pydantic (>= 2.0),
  python3-jinja2,
- python3-yaml
+ python3-yaml,
+ python3-requests,
+ python3-pil
 Standards-Version: 4.6.2
 Homepage: https://github.com/hatlabs/container-packaging-tools
 Vcs-Git: https://github.com/hatlabs/container-packaging-tools.git
@@ -22,6 +24,8 @@ Depends: ${misc:Depends},
  python3-pydantic (>= 2.0),
  python3-jinja2,
  python3-yaml,
+ python3-requests,
+ python3-pil,
  dpkg-dev
 Description: Generate Debian packages from container application definitions
  container-packaging-tools is a command-line tool that converts simple


### PR DESCRIPTION
## Problem

Build-and-release workflow failing with:
```
ModuleNotFoundError: No module named 'PIL'
```

The `assets.py` module uses `requests` and `PIL` (Pillow) but these were not declared in `debian/control`.

## Solution

Added missing dependencies to `debian/control`:
- **`python3-requests`** - Required by assets.py for downloading icons/screenshots
- **`python3-pil`** - Required by assets.py for image validation

Added to both:
- `Build-Depends` - Needed for tests during package build
- `Depends` - Needed for runtime

## Testing

This fix will be tested by the CI build that was previously failing.

## Related

- Fixes workflow: https://github.com/hatlabs/container-packaging-tools/actions/runs/19731933481
- Root cause: PR #97 added assets.py with PIL/requests but didn't update debian/control

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>