### PR TITLE
fix(build): add python3-pil and python3-requests to Docker images

### DIFF
--- a/docker/Dockerfile.debtools
+++ b/docker/Dockerfile.debtools
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get install -y \
     python3-pydantic \
     python3-jinja2 \
     python3-yaml \
+    python3-requests \
+    python3-pil \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory

--- a/docker/Dockerfile.devtools
+++ b/docker/Dockerfile.devtools
@@ -13,6 +13,8 @@ RUN apt-get update && apt-get install -y \
     python3-pydantic \
     python3-jinja2 \
     python3-yaml \
+    python3-requests \
+    python3-pil \
     debhelper \
     dh-python \
     pybuild-plugin-pyproject \


### PR DESCRIPTION
## Problem

Build failures in both CI and local builds due to missing `python3-pil` and `python3-requests` dependencies.

**CI Error:**
```
dpkg-checkbuilddeps: error: unmet build dependencies: python3-pil
```

## Solution

Added missing dependencies to **both** Docker images:

### 1. `Dockerfile.debtools` (used by CI)
- Added `python3-requests`
- Added `python3-pil`

### 2. `Dockerfile.devtools` (used by local builds)
- Added `python3-requests`
- Added `python3-pil`

These dependencies are required by:
- `assets.py` - Uses `requests` for downloading and `PIL` for image validation
- Build tests that import these modules

## Testing

✅ **Local build successful:**
```bash
./run build
# Result: container-packaging-tools_0.2.0-1_all.deb created
```

The CI will test the debtools fix.

## Related

- Completes fix from PR #99 (which updated debian/control)
- Fixes: https://github.com/hatlabs/container-packaging-tools/actions/runs/19732083866

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>