### PR TITLE
feat: auto-create volume directories in systemd service

### DIFF
--- a/src/generate_container_packages/templates/systemd/service.j2
+++ b/src/generate_container_packages/templates/systemd/service.j2
@@ -9,6 +9,7 @@ WorkingDirectory={{ service.working_directory }}
 EnvironmentFile=-{{ service.env_defaults_file }}
 EnvironmentFile=-{{ service.env_file }}
 ExecStartPre=/bin/mkdir -p ${CONTAINER_DATA_ROOT}
+{# Auto-create bind mount directories to prevent "bind source path does not exist" errors #}
 {% for directory in service.volume_directories %}
 ExecStartPre=/bin/mkdir -p {{ directory }}
 {% endfor %}


### PR DESCRIPTION
## Summary

Automatically create all volume bind mount directories before starting containers, preventing "bind source path does not exist" errors.

## Changes

- Extract bind mount paths from docker-compose.yml volumes
- Add ExecStartPre directives to systemd service template to create directories
- Skip system paths (/dev, /sys, etc) and named volumes
- Handle both long and short docker-compose volume format

## Implementation

**template_context.py:**
- Add `_extract_volume_directories()` to parse compose file volumes
- Add `_is_bindable_path()` to filter which paths should be created
- Include volume directories in service context

**service.j2:**
- Add loop to create ExecStartPre for each volume directory
- Directories created after CONTAINER_DATA_ROOT but before docker compose up

## Testing

Resolves hatlabs/halos-imported-containers#20 (directory auto-creation issue)

Related to:
- container-packaging-tools#108 (path isolation fixes)

## Example

Before:
```systemd
ExecStartPre=/bin/mkdir -p ${CONTAINER_DATA_ROOT}
ExecStart=docker compose up
```

After:
```systemd
ExecStartPre=/bin/mkdir -p ${CONTAINER_DATA_ROOT}
ExecStartPre=/bin/mkdir -p ${CONTAINER_DATA_ROOT}/config
ExecStartPre=/bin/mkdir -p ${CONTAINER_DATA_ROOT}/Media
ExecStartPre=/bin/mkdir -p ${CONTAINER_DATA_ROOT}/opt/vc/lib
ExecStart=docker compose up
```
