### PR TITLE
fix: exclude /var/run paths from auto-volume-creation

### DIFF
--- a/src/generate_container_packages/converters/casaos/transformer.py
+++ b/src/generate_container_packages/converters/casaos/transformer.py
@@ -187,9 +187,28 @@ class MetadataTransformer:
         best_score = -1
 
         # Keywords that suggest a supporting/database service (not main)
-        support_keywords = {"postgres", "postgresql", "mysql", "mariadb", "redis", "memcached", "mongo", "mongodb", "db", "database"}
+        support_keywords = {
+            "postgres",
+            "postgresql",
+            "mysql",
+            "mariadb",
+            "redis",
+            "memcached",
+            "mongo",
+            "mongodb",
+            "db",
+            "database",
+        }
         # Keywords that suggest main service
-        main_keywords = {"server", "app", "web", "api", "frontend", "backend", "service"}
+        main_keywords = {
+            "server",
+            "app",
+            "web",
+            "api",
+            "frontend",
+            "backend",
+            "service",
+        }
 
         for service in casaos_app.services:
             service_lower = service.name.lower()
@@ -199,7 +218,9 @@ class MetadataTransformer:
             if service_lower == app_id_lower:
                 score = 1000
             # Starts with app.id (e.g., "immich-server" for "immich")
-            elif service_lower.startswith(app_id_lower + "-") or service_lower.startswith(app_id_lower + "_"):
+            elif service_lower.startswith(
+                app_id_lower + "-"
+            ) or service_lower.startswith(app_id_lower + "_"):
                 score = 100
                 # Bonus for main keywords
                 for keyword in main_keywords:
@@ -217,9 +238,12 @@ class MetadataTransformer:
             # Contains app.id as word boundary
             elif app_id_lower in service_lower:
                 idx = service_lower.find(app_id_lower)
-                before_ok = idx == 0 or not service_lower[idx-1].isalnum()
+                before_ok = idx == 0 or not service_lower[idx - 1].isalnum()
                 after_idx = idx + len(app_id_lower)
-                after_ok = after_idx >= len(service_lower) or not service_lower[after_idx].isalnum()
+                after_ok = (
+                    after_idx >= len(service_lower)
+                    or not service_lower[after_idx].isalnum()
+                )
                 if before_ok and after_ok:
                     score = 50
 
@@ -425,7 +449,16 @@ class MetadataTransformer:
         tag = image_tag.split(":")[-1]
 
         # Skip branch tags and latest
-        skip_tags = {"latest", "main", "master", "stable", "develop", "dev", "nightly", "edge"}
+        skip_tags = {
+            "latest",
+            "main",
+            "master",
+            "stable",
+            "develop",
+            "dev",
+            "nightly",
+            "edge",
+        }
         if tag.lower() in skip_tags:
             return None
 
@@ -448,8 +481,7 @@ class MetadataTransformer:
             # Check if suffix starts with a pre-release keyword
             suffix_lower = suffix.lower()
             is_prerelease = any(
-                suffix_lower.startswith(keyword)
-                for keyword in prerelease_keywords
+                suffix_lower.startswith(keyword) for keyword in prerelease_keywords
             )
 
             if is_prerelease:

--- a/src/generate_container_packages/template_context.py
+++ b/src/generate_container_packages/template_context.py
@@ -153,7 +153,7 @@ def _is_bindable_path(path: str) -> bool:
     Validates that the path is safe to create as a bind mount directory:
     1. Must be an absolute path or contain allowed environment variables
     2. Must not be a named volume (no slashes = named volume)
-    3. Must not reference system paths (/dev, /sys, /proc, /run, /tmp)
+    3. Must not reference system paths (/dev, /sys, /proc, /run, /var/run, /tmp)
     4. Must not contain path traversal attempts (..)
     5. Environment variables must be from an allowed list for security
 
@@ -184,7 +184,8 @@ def _is_bindable_path(path: str) -> bool:
         return False
 
     # Skip system paths that should never be created
-    system_prefixes = ("/dev", "/sys", "/proc", "/run", "/tmp")
+    # Note: /var/run is a symlink to /run on systemd systems
+    system_prefixes = ("/dev", "/sys", "/proc", "/run", "/var/run", "/tmp")
     for prefix in system_prefixes:
         if path.startswith(prefix):
             return False
@@ -201,9 +202,7 @@ def _is_bindable_path(path: str) -> bool:
             "$USER",
         )
         # Check if path starts with or contains any allowed env var
-        has_allowed_var = any(
-            allowed_var in path for allowed_var in allowed_env_vars
-        )
+        has_allowed_var = any(allowed_var in path for allowed_var in allowed_env_vars)
         if not has_allowed_var:
             # Reject paths with unknown/potentially dangerous env vars
             return False

--- a/tests/converters/casaos/test_transformer.py
+++ b/tests/converters/casaos/test_transformer.py
@@ -835,46 +835,87 @@ class TestVersionExtraction:
         self, transformer: MetadataTransformer
     ) -> None:
         """Test standard semantic version extraction."""
-        assert transformer._extract_version_from_image("linuxserver/sonarr:4.0.15") == "4.0.15"
+        assert (
+            transformer._extract_version_from_image("linuxserver/sonarr:4.0.15")
+            == "4.0.15"
+        )
         assert transformer._extract_version_from_image("postgres:17.4") == "17.4"
-        assert transformer._extract_version_from_image("jellyfin/jellyfin:10.10.7") == "10.10.7"
-        assert transformer._extract_version_from_image("portainer/portainer-ce:2.31.3") == "2.31.3"
+        assert (
+            transformer._extract_version_from_image("jellyfin/jellyfin:10.10.7")
+            == "10.10.7"
+        )
+        assert (
+            transformer._extract_version_from_image("portainer/portainer-ce:2.31.3")
+            == "2.31.3"
+        )
 
     def test_extract_version_with_v_prefix(
         self, transformer: MetadataTransformer
     ) -> None:
         """Test v-prefix is stripped from version."""
-        assert transformer._extract_version_from_image("tailscale/tailscale:v1.90.8") == "1.90.8"
-        assert transformer._extract_version_from_image("adguard/adguardhome:v0.107.61") == "0.107.61"
-        assert transformer._extract_version_from_image("ghcr.io/gohugoio/hugo:v0.148.2") == "0.148.2"
+        assert (
+            transformer._extract_version_from_image("tailscale/tailscale:v1.90.8")
+            == "1.90.8"
+        )
+        assert (
+            transformer._extract_version_from_image("adguard/adguardhome:v0.107.61")
+            == "0.107.61"
+        )
+        assert (
+            transformer._extract_version_from_image("ghcr.io/gohugoio/hugo:v0.148.2")
+            == "0.148.2"
+        )
 
     def test_extract_version_with_suffix(
         self, transformer: MetadataTransformer
     ) -> None:
         """Test version extraction with suffixes like -alpine."""
-        assert transformer._extract_version_from_image("louislam/uptime-kuma:1.23.16-alpine") == "1.23.16"
+        assert (
+            transformer._extract_version_from_image(
+                "louislam/uptime-kuma:1.23.16-alpine"
+            )
+            == "1.23.16"
+        )
         assert transformer._extract_version_from_image("postgres:15-alpine") == "15"
         assert transformer._extract_version_from_image("redis:6.2-alpine3.22") == "6.2"
-        assert transformer._extract_version_from_image("nginx:1.25.3-bookworm") == "1.25.3"
+        assert (
+            transformer._extract_version_from_image("nginx:1.25.3-bookworm") == "1.25.3"
+        )
 
-    def test_extract_date_based_version(
-        self, transformer: MetadataTransformer
-    ) -> None:
+    def test_extract_date_based_version(self, transformer: MetadataTransformer) -> None:
         """Test date-based version extraction."""
-        assert transformer._extract_version_from_image("photoprism/photoprism:250228") == "250228"
-        assert transformer._extract_version_from_image("actualbudget/actual-server:25.7.1") == "25.7.1"
-        assert transformer._extract_version_from_image("anaconda3:2024.10-1") == "2024.10-1"
+        assert (
+            transformer._extract_version_from_image("photoprism/photoprism:250228")
+            == "250228"
+        )
+        assert (
+            transformer._extract_version_from_image("actualbudget/actual-server:25.7.1")
+            == "25.7.1"
+        )
+        assert (
+            transformer._extract_version_from_image("anaconda3:2024.10-1")
+            == "2024.10-1"
+        )
 
     def test_extract_version_with_digest(
         self, transformer: MetadataTransformer
     ) -> None:
         """Test version extraction from image with digest reference."""
-        assert transformer._extract_version_from_image("redis:6.2-alpine@sha256:abc123def") == "6.2"
-        assert transformer._extract_version_from_image("nginx:1.25@sha256:fedcba987") == "1.25"
+        assert (
+            transformer._extract_version_from_image("redis:6.2-alpine@sha256:abc123def")
+            == "6.2"
+        )
+        assert (
+            transformer._extract_version_from_image("nginx:1.25@sha256:fedcba987")
+            == "1.25"
+        )
 
     def test_skip_latest_tag(self, transformer: MetadataTransformer) -> None:
         """Test that :latest tags are skipped (return None)."""
-        assert transformer._extract_version_from_image("homebridge/homebridge:latest") is None
+        assert (
+            transformer._extract_version_from_image("homebridge/homebridge:latest")
+            is None
+        )
         assert transformer._extract_version_from_image("duckdns:latest") is None
         assert transformer._extract_version_from_image("excalidraw:latest") is None
 
@@ -895,15 +936,23 @@ class TestVersionExtraction:
         self, transformer: MetadataTransformer
     ) -> None:
         """Test version extraction with full registry path."""
-        assert transformer._extract_version_from_image("ghcr.io/linuxserver/sonarr:4.0.15") == "4.0.15"
-        assert transformer._extract_version_from_image("docker.io/library/postgres:15") == "15"
+        assert (
+            transformer._extract_version_from_image("ghcr.io/linuxserver/sonarr:4.0.15")
+            == "4.0.15"
+        )
+        assert (
+            transformer._extract_version_from_image("docker.io/library/postgres:15")
+            == "15"
+        )
 
     def test_extract_multi_digit_versions(
         self, transformer: MetadataTransformer
     ) -> None:
         """Test extraction of multi-digit version numbers."""
         assert transformer._extract_version_from_image("app:10.20.30") == "10.20.30"
-        assert transformer._extract_version_from_image("app:v100.200.300") == "100.200.300"
+        assert (
+            transformer._extract_version_from_image("app:v100.200.300") == "100.200.300"
+        )
 
     def test_extract_prerelease_rc_versions(
         self, transformer: MetadataTransformer
@@ -911,16 +960,26 @@ class TestVersionExtraction:
         """Test RC versions are converted to Debian format with tilde."""
         assert transformer._extract_version_from_image("app:1.2.3-rc1") == "1.2.3~rc1"
         assert transformer._extract_version_from_image("app:1.2.3-RC2") == "1.2.3~RC2"
-        assert transformer._extract_version_from_image("app:v2.0.0-rc.1") == "2.0.0~rc.1"
+        assert (
+            transformer._extract_version_from_image("app:v2.0.0-rc.1") == "2.0.0~rc.1"
+        )
         assert transformer._extract_version_from_image("app:1.0.0-rc") == "1.0.0~rc"
 
     def test_extract_prerelease_beta_alpha_versions(
         self, transformer: MetadataTransformer
     ) -> None:
         """Test beta/alpha versions are converted to Debian format with tilde."""
-        assert transformer._extract_version_from_image("app:1.2.3-beta1") == "1.2.3~beta1"
-        assert transformer._extract_version_from_image("app:1.2.3-beta.2") == "1.2.3~beta.2"
-        assert transformer._extract_version_from_image("app:1.2.3-alpha1") == "1.2.3~alpha1"
+        assert (
+            transformer._extract_version_from_image("app:1.2.3-beta1") == "1.2.3~beta1"
+        )
+        assert (
+            transformer._extract_version_from_image("app:1.2.3-beta.2")
+            == "1.2.3~beta.2"
+        )
+        assert (
+            transformer._extract_version_from_image("app:1.2.3-alpha1")
+            == "1.2.3~alpha1"
+        )
         assert transformer._extract_version_from_image("app:2.0.0-pre1") == "2.0.0~pre1"
         assert transformer._extract_version_from_image("app:1.5.0-dev") == "1.5.0~dev"
 
@@ -963,7 +1022,8 @@ class TestVersionExtraction:
         # Source metadata should track extraction
         assert result["metadata"]["source_metadata"] is None or (
             "version_source" not in result["metadata"].get("source_metadata", {})
-            or result["metadata"]["source_metadata"]["version_source"] == "auto-extracted"
+            or result["metadata"]["source_metadata"]["version_source"]
+            == "auto-extracted"
         )
 
     def test_transform_multi_service_app_uses_matching_service(

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -485,11 +485,7 @@ class TestInjectHomarrLabels:
         """Test that no labels are added when web_ui is disabled."""
         from generate_container_packages.builder import inject_homarr_labels
 
-        compose = {
-            "services": {
-                "app": {"image": "myapp:latest"}
-            }
-        }
+        compose = {"services": {"app": {"image": "myapp:latest"}}}
         metadata = {
             "name": "My App",
             "package_name": "myapp-container",

--- a/tests/test_template_context.py
+++ b/tests/test_template_context.py
@@ -269,6 +269,7 @@ class TestIsBindablePath:
         assert not _is_bindable_path("/sys/class/gpio")
         assert not _is_bindable_path("/proc/cpuinfo")
         assert not _is_bindable_path("/run/docker.sock")
+        assert not _is_bindable_path("/var/run/dbus/system_bus_socket")
         assert not _is_bindable_path("/tmp/cache")
 
     def test_rejects_path_traversal(self):


### PR DESCRIPTION
## Summary

- Add `/var/run` to the system path exclusion list in `_is_bindable_path()`
- On systemd systems, `/var/run` is a symlink to `/run`, so paths like `/var/run/dbus/system_bus_socket` need to be excluded from auto-creation

## Root Cause

The auto-volume-creation feature (PR #110) attempts to `mkdir -p` bind mount source paths before starting containers. It excluded `/run` but not `/var/run`, causing the systemd service to fail with:

```
mkdir: cannot create directory '/var/run/dbus/system_bus_socket': File exists
```

## Test plan

- [x] Added test case for `/var/run/dbus/system_bus_socket` in `test_rejects_system_paths`
- [x] All existing tests pass

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)