### PR TITLE
feat: add generate_secrets support for auto-generating secrets

### DIFF
--- a/src/generate_container_packages/template_context.py
+++ b/src/generate_container_packages/template_context.py
@@ -27,6 +27,7 @@ def build_context(app_def: AppDefinition) -> dict[str, Any]:
         "paths": _build_paths(package_name),
         "web_ui": metadata.get("web_ui", {}),
         "default_config": metadata.get("default_config", {}),
+        "generate_secrets": metadata.get("generate_secrets", {}),
         "timestamp": app_def.timestamp,
         "timestamp_rfc2822": app_def.timestamp_rfc2822,
         "date_only": app_def.date_only,

--- a/src/generate_container_packages/templates/debian/postinst.j2
+++ b/src/generate_container_packages/templates/debian/postinst.j2
@@ -13,6 +13,24 @@ case "$1" in
         if [ ! -f "{{ paths.etc }}/env" ]; then
             cp "{{ paths.lib }}/env.user-template" "{{ paths.etc }}/env"
         fi
+{% if generate_secrets %}
+
+        # Generate secrets for keys that need auto-generation
+        ENV_FILE="{{ paths.etc }}/env"
+{% for key, generator in generate_secrets.items() %}
+{% if generator == "hex32" %}
+        # Generate {{ key }} if empty or not set
+        if ! grep -q "^{{ key }}=.\+" "$ENV_FILE" 2>/dev/null; then
+            NEW_SECRET=$(openssl rand -hex 32)
+            # Remove any existing empty entry
+            sed -i '/^{{ key }}=/d' "$ENV_FILE" 2>/dev/null || true
+            # Add new secret
+            echo "{{ key }}=$NEW_SECRET" >> "$ENV_FILE"
+            echo "Generated new {{ key }}"
+        fi
+{% endif %}
+{% endfor %}
+{% endif %}
 
         # Only interact with systemd if it's running (not in containers or minimal envs)
         if [ -d /run/systemd/system ]; then


### PR DESCRIPTION
## Summary

Add support for automatically generating secrets during package install.

- Add `generate_secrets` field to template context from metadata.yaml
- Update postinst template to generate hex32 secrets on first install
- Secrets are only generated if the value is empty or not set

## Example Usage

In metadata.yaml:
```yaml
generate_secrets:
  SECRET_ENCRYPTION_KEY: hex32
```

This will auto-generate a 64-character hex string (32 bytes) for `SECRET_ENCRYPTION_KEY` during package installation if it's not already set.

## Motivation

Apps like Homarr require encryption keys that should be auto-generated on first install. Without this feature, the container fails to start with "Invalid environment variables" errors.

## Test plan

- [ ] Unit tests pass
- [ ] Build homarr-container with generate_secrets and verify key is auto-generated
- [ ] Verify existing secrets are not overwritten on upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)