### PR TITLE
feat(validator): enforce container lifecycle conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,39 @@ Tooling for generating Debian packages from container application definitions.
 
 **Local Instructions**: For environment-specific instructions and configurations, see @CLAUDE.local.md (not committed to version control).
 
+## Container Lifecycle Conventions
+
+All container apps must follow these conventions in their `docker-compose.yml`:
+
+### Restart Policy
+
+```yaml
+services:
+  myapp:
+    restart: unless-stopped
+```
+
+**Rationale**: Docker handles per-container restarts (fast recovery for individual containers). Systemd is the fallback for compose process failures. This is critical for multi-service compose files where sidekick containers can crash independently.
+
+### Logging Driver
+
+```yaml
+services:
+  myapp:
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
+```
+
+**Rationale**: Provides unified logging via `journalctl -u <service>` with per-container filtering using `journalctl CONTAINER_NAME=<container>`. Eliminates log duplication (no separate json-file storage).
+
+### Validation
+
+The validator enforces these conventions as **blocking errors**. Apps that don't follow them will fail to build.
+
+See [halos-distro#49](https://github.com/hatlabs/halos-distro/issues/49) for the full design rationale.
+
 ## Git Workflow Policy
 
 **Branch Workflow:** Never push to main directly - always use feature branches and PRs.

--- a/src/generate_container_packages/converters/casaos/transformer.py
+++ b/src/generate_container_packages/converters/casaos/transformer.py
@@ -712,7 +712,13 @@ class MetadataTransformer:
         for service in casaos_app.services:
             service_def: dict[str, Any] = {
                 "image": service.image,
-                "restart": "no",
+                "restart": "unless-stopped",
+                "logging": {
+                    "driver": "journald",
+                    "options": {
+                        "tag": "{{.Name}}",
+                    },
+                },
             }
 
             # Add environment variables (as dict)

--- a/tests/fixtures/valid/full-app/docker-compose.yml
+++ b/tests/fixtures/valid/full-app/docker-compose.yml
@@ -26,7 +26,11 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-    restart: "no"
+    restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"
     networks:
       - app-network
 

--- a/tests/fixtures/valid/simple-app/docker-compose.yml
+++ b/tests/fixtures/valid/simple-app/docker-compose.yml
@@ -10,4 +10,8 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
       - /var/lib/container-apps/simple-test-app-container/data:/usr/share/nginx/html:rw
-    restart: "no"
+    restart: unless-stopped
+    logging:
+      driver: journald
+      options:
+        tag: "{{.Name}}"


### PR DESCRIPTION
## Summary

- Add validation for container lifecycle conventions (blocking errors)
- Update CasaOS converter to produce compliant compose files
- Document new conventions in AGENTS.md

## Container Lifecycle Conventions

All container apps must now follow these conventions:

### Restart Policy
```yaml
restart: unless-stopped
```
Docker handles per-container restarts, systemd is fallback for compose process failures.

### Logging Driver
```yaml
logging:
  driver: journald
  options:
    tag: "{{.Name}}"
```
Unified logging via `journalctl -u <service>` with per-container filtering.

## Changes

| File | Change |
|------|--------|
| `validator.py` | Add `_validate_lifecycle_conventions()`, remove old warning |
| `transformer.py` | Update CasaOS converter to produce compliant output |
| `test_validator.py` | Add `TestLifecycleConventions` test class |
| Test fixtures | Update to follow conventions |
| `AGENTS.md` | Document conventions |

## Breaking Change

Container apps that don't follow these conventions will fail validation. This is intentional - see the tracking issue for rationale.

## Test Plan

- [x] Unit tests pass: `uv run pytest tests/test_*.py -m "not integration and not install" -q`
- [x] Integration tests pass: `uv run pytest tests/test_*.py -m "integration and not install" -q`
- [x] Lint passes: `./run lint`
- [x] Typecheck passes for modified files

## Related

- Closes #124
- Part of hatlabs/halos-distro#49
- Unblocks hatlabs/halos-core-containers#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)