### PR TITLE
fix: exclude file mounts from auto-created directories

### DIFF
--- a/tests/test_template_context.py
+++ b/tests/test_template_context.py
@@ -291,6 +291,44 @@ class TestIsBindablePath:
         assert not _is_bindable_path("./data")
         assert not _is_bindable_path("config/files")
 
+    def test_rejects_file_paths(self):
+        """Test that paths ending with file extensions are rejected."""
+        # Config file extensions
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/nginx.conf")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/settings.json")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/config.yaml")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/config.yml")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/settings.xml")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/app.toml")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/settings.ini")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/config.cfg")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/vars.env")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/readme.txt")
+        # Socket and system files
+        assert not _is_bindable_path("/var/lib/app/app.sock")
+        assert not _is_bindable_path("/var/lib/app/app.socket")
+        assert not _is_bindable_path("/var/lib/app/app.pid")
+        assert not _is_bindable_path("/var/lib/app/app.log")
+        # Case insensitive
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/Config.JSON")
+        assert not _is_bindable_path("${CONTAINER_DATA_ROOT}/settings.YAML")
+
+    def test_accepts_directory_paths(self):
+        """Test that directory-like paths are still accepted."""
+        # Paths without file extensions
+        assert _is_bindable_path("${CONTAINER_DATA_ROOT}/config")
+        assert _is_bindable_path("${CONTAINER_DATA_ROOT}/data")
+        assert _is_bindable_path("${CONTAINER_DATA_ROOT}/logs")
+        assert _is_bindable_path("/opt/myapp/storage")
+
+    def test_accepts_hidden_directories(self):
+        """Test that hidden directories (starting with .) are accepted."""
+        # Hidden directories should be allowed, not mistaken for file extensions
+        assert _is_bindable_path("${HOME}/.config")
+        assert _is_bindable_path("${HOME}/.local")
+        assert _is_bindable_path("${HOME}/.cache")
+        assert _is_bindable_path("/opt/app/.data")
+
 
 class TestExtractVolumeDirectories:
     """Tests for _extract_volume_directories function."""


### PR DESCRIPTION
## Summary

- Add detection of file paths in `_is_bindable_path()` to exclude them from `volume_directories`
- Common file extensions (.conf, .json, .yaml, etc.) are now detected and excluded
- Hidden directories (like `.config`) are still allowed

## Problem

The systemd service template was generating `mkdir -p` for ALL volume sources:

```
ExecStartPre=/bin/mkdir -p ${CONTAINER_DATA_ROOT}/nginx-assets.conf
```

When the volume source is actually a file (not a directory), this creates a directory instead, causing Docker to fail:

```
error mounting ".../nginx-assets.conf" to "/etc/nginx/conf.d/default.conf": 
cannot mkdir: not a directory
```

## Solution

Added file extension detection to `_is_bindable_path()`:

```python
file_extensions = (".conf", ".json", ".yaml", ".yml", ".xml", ...)

basename = path.rsplit("/", 1)[-1].lower()
for ext in file_extensions:
    if basename.endswith(ext) and len(basename) > len(ext) and basename[-len(ext) - 1] != ".":
        return False
```

The logic checks that there's a non-dot character before the extension, which allows hidden directories like `.config` while blocking files like `nginx.conf`.

## Test plan

- [x] All existing tests pass (33 tests)
- [x] New tests for file path rejection pass
- [x] New tests for hidden directory acceptance pass
- [x] Verified fix works on halos.local

🤖 Generated with [Claude Code](https://claude.com/claude-code)