### PR TITLE
feat: add lefthook pre-commit hooks for format/lint checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,28 @@ All development happens in Docker containers to ensure consistent Debian Trixie 
 ./run docker:shell
 ```
 
+### Pre-commit Hooks
+
+This project uses [lefthook](https://github.com/evilmartians/lefthook) for pre-commit hooks to run lint checks locally before commits.
+
+```bash
+# Install lefthook (one-time)
+brew install lefthook
+
+# Enable hooks in this repo
+./run hooks-install
+```
+
+**What it checks:**
+
+- `ruff check src/ tests/` - Linting
+
+**Skip hooks when needed:**
+
+```bash
+git commit --no-verify -m "WIP: message"
+```
+
 ### Code Quality
 
 Before submitting changes, ensure all checks pass:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: true
+  commands:
+    ruff-check:
+      glob: "*.py"
+      run: |
+        if command -v uv >/dev/null 2>&1; then
+          uv run ruff check src/ tests/
+        elif command -v ruff >/dev/null 2>&1; then
+          ruff check src/ tests/
+        else
+          echo "WARNING: ruff not found, skipping"
+          exit 0
+        fi
+      fail_text: "Run 'ruff check src/ tests/' to see issues."

--- a/run
+++ b/run
@@ -37,6 +37,27 @@ function bumpversion {
   command bumpversion "$@"
 }
 
+function hooks-install {
+  #@ Install pre-commit hooks using lefthook
+  #@ Category: Development
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook install
+  echo "✅ Pre-commit hooks installed"
+}
+
+function hooks-run {
+  #@ Run pre-commit hooks manually
+  #@ Category: Development
+  if ! command -v lefthook &> /dev/null; then
+    echo "Error: lefthook not found. Install with: brew install lefthook"
+    exit 1
+  fi
+  lefthook run pre-commit
+}
+
 ################################################################################
 # Setup Commands
 


### PR DESCRIPTION
## Summary

- Add lefthook.yml with ruff check
- Add hooks-install command to run script  
- Update README with developer setup instructions

## Test plan

- [x] Tested `lefthook run pre-commit` locally
- [x] Verified run script `hooks-install` command works
- [x] Confirmed hooks run on commit

## Developer Setup

After merging, developers should:
```bash
brew install lefthook
./run hooks-install
```

Fixes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)