### PR TITLE
fix(templates): use VolumeInfo.path in systemd service template

### DIFF
--- a/src/generate_container_packages/templates/systemd/service.j2
+++ b/src/generate_container_packages/templates/systemd/service.j2
@@ -10,11 +10,6 @@ ExecStartPre={{ service.working_directory }}/prestart.sh
 EnvironmentFile=-{{ service.env_defaults_file }}
 EnvironmentFile=-{{ service.env_file }}
 EnvironmentFile=-{{ service.runtime_env_file }}
-ExecStartPre=/bin/mkdir -p ${CONTAINER_DATA_ROOT}
-{# Auto-create bind mount directories to prevent "bind source path does not exist" errors #}
-{% for directory in service.volume_directories %}
-ExecStartPre=/bin/mkdir -p {{ directory.path }}
-{% endfor %}
 ExecStart=docker compose up
 ExecStop=docker compose down
 Restart=on-failure


### PR DESCRIPTION
## Summary

Removed redundant volume directory handling from systemd service template. This fixes the VolumeInfo bug by eliminating the problematic code entirely.

## Problem

The systemd service template had a loop that created volume directories at service start:

```jinja2
{% for directory in service.volume_directories %}
ExecStartPre=/bin/mkdir -p {{ directory }}
{% endfor %}
```

This had three issues:
1. **Bug**: Used `{{ directory }}` instead of `{{ directory.path }}`, rendering `VolumeInfo(path=...)` as directory names
2. **Duplication**: Same logic already exists in `postinst.j2` (which runs at package install)
3. **Silent failures**: Masked misconfigurations by recreating deleted directories

## Solution

Removed the volume directory handling from systemd entirely. Directory creation and ownership is now handled **exclusively by postinst** during package installation.

If directories are missing at service start, Docker will fail with a clear "bind source path does not exist" error rather than silently recreating them.

## Test plan

- [x] Unit tests pass
- [x] Test verifies systemd service contains no mkdir/chown/CONTAINER_DATA_ROOT references
- [x] All quality checks pass (lint, format, typecheck)
- [x] Malformed directories cleaned up on halos.local

🤖 Generated with [Claude Code](https://claude.com/claude-code)