### PR TITLE
fix(templates): VolumeInfo bug fix and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ services:
     restart: "no"
 ```
 
+> **Note: Non-Root Containers**
+> If your container runs as a non-root user (like Grafana UID 472), add `user: "472"` to docker-compose.yml. This ensures the tool generates correct directory ownership in the postinst script. See [EXAMPLES.md - Pattern 6](EXAMPLES.md#pattern-6-non-root-container-with-volume-permissions) for details.
+
 **config.yml** - Configuration schema:
 ```yaml
 version: "1.0"


### PR DESCRIPTION
## Summary

This PR includes:

1. **Bug fixes for VolumeInfo template rendering** - Fixes issues with volume directory handling in systemd service templates
2. **Documentation for non-root container volume permissions** - Adds comprehensive documentation explaining how to use the `user` field in docker-compose.yml

## Documentation Changes

Added to EXAMPLES.md:
- **Pattern 6: Non-Root Container with Volume Permissions** - Explains why and how to use the `user` field
- **Troubleshooting entry** for "Permission denied" volume errors
- Updated Table of Contents

Added to README.md:
- Note in Quick Start section about non-root containers

## Why This Documentation Matters

Many containers run as non-root users for security (e.g., Grafana runs as UID 472). When the `user` field is specified in docker-compose.yml, the tool automatically:
1. Detects the UID/GID at build time
2. Generates a `postinst` script that creates data directories with correct ownership

Without this, containers fail to start with "permission denied" errors because Docker creates bind mount directories as root.

## Test plan

- [x] Documentation renders correctly in GitHub
- [x] Links in TOC work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)