### PR TITLE
fix: add has_web_ui block to correct template location

### DIFF
--- a/src/generate_container_packages/templates/debian/rules.j2
+++ b/src/generate_container_packages/templates/debian/rules.j2
@@ -35,6 +35,12 @@ override_dh_auto_install:
 {% endfor %}
 {% endif %}
 
+{% if has_web_ui %}
+	# Install app registry file for homarr-container-adapter
+	install -D -m 644 webapp-registry.toml \
+		debian/{{ package.name }}/etc/halos/webapps.d/{{ package.name }}.toml
+{% endif %}
+
 	# Install systemd service file
 	install -D -m 644 debian/{{ package.name }}.service \
 		debian/{{ package.name }}/{{ paths.systemd }}/{{ package.name }}.service


### PR DESCRIPTION
## Summary

The `has_web_ui` installation block was added to `templates/debian/rules.j2` but the package actually uses `src/generate_container_packages/templates/debian/rules.j2`.

This fix adds the `webapp-registry.toml` installation to the correct template location.

## Root Cause

There are two template directories in this repo:
- `templates/` - appears to be outdated/unused
- `src/generate_container_packages/templates/` - actually used by the package

PR #141 updated the wrong location.

## Test Plan
- [x] Local verification that rendered rules.j2 now includes webapp-registry install

🤖 Generated with [Claude Code](https://claude.com/claude-code)