### PR TITLE
fix: remove templates copy from debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,9 +7,8 @@ export PYBUILD_NAME=generate-container-packages
 
 override_dh_auto_install:
 	dh_auto_install
-	# Install templates to /usr/share/container-packaging-tools/
-	mkdir -p debian/container-packaging-tools/usr/share/container-packaging-tools
-	cp -r templates debian/container-packaging-tools/usr/share/container-packaging-tools/
+	# Templates are now bundled inside the Python package (generate_container_packages/templates/)
+	# No need to copy to /usr/share - they're installed via pip/wheel
 
 override_dh_builddeb:
 	dh_builddeb --destdir=.

--- a/src/generate_container_packages/renderer.py
+++ b/src/generate_container_packages/renderer.py
@@ -114,28 +114,19 @@ def write_rendered_file(content: str, output_path: Path) -> None:
 
 
 def _find_template_directory() -> Path:
-    """Find template directory (installed or local).
+    """Find template directory bundled with the package.
 
     Returns:
         Path to templates directory
 
-    Tries these locations in order:
-    1. Package bundled location: templates/ inside the package
-    2. Installed location: /usr/share/container-packaging-tools/templates/
+    Raises:
+        FileNotFoundError: If templates directory is not found
     """
-    # Try package bundled location first (for pip/uvx installations)
     package_path = Path(__file__).parent / "templates"
     if package_path.exists():
         return package_path
 
-    # Try Debian package install location
-    installed_path = Path("/usr/share/container-packaging-tools/templates")
-    if installed_path.exists():
-        return installed_path
-
-    raise FileNotFoundError(
-        f"Cannot find templates directory. Checked:\n  - {package_path}\n  - {installed_path}"
-    )
+    raise FileNotFoundError(f"Cannot find templates directory at: {package_path}")
 
 
 def _copy_static_files(template_dir: Path, output_dir: Path) -> None:


### PR DESCRIPTION
## Summary
- Remove obsolete templates copy step from debian/rules since templates are now bundled in the Python package
- Simplify `_find_template_directory()` to only check the bundled location

This fixes the build failure on main after the visible-field PR was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)