### PR TITLE
refactor: remove build-time Traefik label generation

### DIFF
--- a/src/generate_container_packages/builder.py
+++ b/src/generate_container_packages/builder.py
@@ -15,7 +15,7 @@ from generate_container_packages.oidc_snippet import generate_oidc_snippet
 from generate_container_packages.prestart import generate_prestart_script
 from generate_container_packages.registry import generate_registry_toml
 from generate_container_packages.routing import generate_routing_yml
-from generate_container_packages.traefik import inject_traefik_labels
+from generate_container_packages.traefik import inject_traefik_network
 
 
 class BuildError(Exception):
@@ -142,10 +142,8 @@ def copy_source_files(app_def: AppDefinition, source_dir: Path) -> None:
         app_def.compose, app_def.metadata, app_def.icon_path
     )
 
-    # Inject Traefik labels and network
-    compose_with_labels = inject_traefik_labels(
-        compose_with_labels, app_def.metadata, app_def.compose
-    )
+    # Inject Traefik network (labels generated at runtime from routing.yml)
+    compose_with_labels = inject_traefik_network(compose_with_labels, app_def.metadata)
 
     # Fix boolean restart values that PyYAML parsed from "no"/"yes"
     compose_with_labels = _fix_restart_policy(compose_with_labels)


### PR DESCRIPTION
## Summary

This PR removes build-time Traefik label generation in favor of runtime generation by the Traefik container.

### Changes
- Simplify `traefik.py` to only inject the proxy network (no labels)
- Delete `middleware.py` (middleware is now generated at runtime)
- Update `builder.py` to use the simplified `inject_traefik_network()`
- Remove `has_custom_forward_auth` from template context
- Add `has_routing` flag for routing.yml installation
- Remove `traefik-middleware.yml` installation from `rules.j2`
- Remove middleware cleanup from `postrm.j2`
- Update tests to match new functionality

### Benefits
- Decouples app packages from Traefik-specific configuration
- Enables domain changes without package rebuilds
- Simplifies package generation logic
- Reduces build-time complexity

### Dependencies
- **Depends on**: #159 (routing.yml generation - Phase 1)
- **Related**: hatlabs/halos-core-containers#45 (runtime label generation - Phase 2)

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Code quality checks pass (lint, format, typecheck)

Part of: https://github.com/hatlabs/halos-distro/issues/58
Closes: https://github.com/hatlabs/container-packaging-tools/issues/158

🤖 Generated with [Claude Code](https://claude.com/claude-code)