### PR TITLE
refactor: remove deprecated traefik field from schema

### DIFF
--- a/src/generate_container_packages/traefik.py
+++ b/src/generate_container_packages/traefik.py
@@ -147,16 +147,11 @@ def inject_traefik_network(
     Returns:
         Modified docker-compose with network added (if needed)
     """
-    traefik_config = metadata.get("traefik")
     routing_config = metadata.get("routing")
     web_ui = metadata.get("web_ui")
 
     # Check if routing is needed
-    has_routing = (
-        traefik_config is not None
-        or routing_config is not None
-        or (web_ui and web_ui.get("enabled"))
-    )
+    has_routing = routing_config is not None or (web_ui and web_ui.get("enabled"))
 
     if not has_routing:
         return compose

--- a/src/schemas/metadata.py
+++ b/src/schemas/metadata.py
@@ -243,6 +243,8 @@ class PackageMetadata(BaseModel):
     Note: package_name is computed at build time from app_id and prefix.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     # Required identity fields
     name: str = Field(min_length=1, description="Human-readable application name")
     app_id: str = Field(
@@ -368,14 +370,9 @@ class PackageMetadata(BaseModel):
         None, description="Homarr dashboard layout configuration"
     )
 
-    # Routing configuration (new generic format)
+    # Routing configuration (generic format)
     routing: RoutingConfig | None = Field(
-        None, description="Generic routing configuration (preferred)"
-    )
-
-    # Traefik routing and SSO configuration (legacy, for backwards compatibility)
-    traefik: TraefikConfig | None = Field(
-        None, description="Traefik routing and SSO configuration (legacy)"
+        None, description="Generic routing configuration"
     )
 
     # Default configuration

--- a/tests/test_routing_schema.py
+++ b/tests/test_routing_schema.py
@@ -127,26 +127,14 @@ class TestPackageMetadataWithRouting:
         assert metadata.routing is not None
         assert metadata.routing.subdomain == "testapp"
 
-    def test_traefik_field_still_works(self, base_metadata: dict) -> None:
-        """traefik field should still work for backwards compatibility."""
+    def test_traefik_field_is_rejected(self, base_metadata: dict) -> None:
+        """traefik field should be rejected (deprecated)."""
         base_metadata["traefik"] = {
             "subdomain": "testapp",
             "auth": "forward_auth",
         }
-        metadata = PackageMetadata(**base_metadata)
-        assert metadata.traefik is not None
-        assert metadata.traefik.subdomain == "testapp"
-
-    def test_both_routing_and_traefik_routing_takes_precedence(
-        self, base_metadata: dict
-    ) -> None:
-        """When both are specified, routing takes precedence."""
-        base_metadata["routing"] = {"subdomain": "routing-subdomain"}
-        base_metadata["traefik"] = {"subdomain": "traefik-subdomain"}
-        metadata = PackageMetadata(**base_metadata)
-        # routing should be preferred
-        assert metadata.routing is not None
-        assert metadata.routing.subdomain == "routing-subdomain"
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            PackageMetadata(**base_metadata)
 
     def test_full_routing_config(self, base_metadata: dict) -> None:
         """Full routing config should be valid."""

--- a/tests/test_templates_oidc.py
+++ b/tests/test_templates_oidc.py
@@ -22,13 +22,9 @@ class TestOIDCPostinst:
             "tags": ["role::container-app"],
             "debian_section": "net",
             "architecture": "all",
-            "traefik": {
+            "routing": {
                 "subdomain": "oidc",
-                "auth": "oidc",
-                "oidc": {
-                    "client_name": "OIDC App",
-                    "redirect_path": "/callback",
-                },
+                "auth": {"mode": "oidc"},
             },
         }
 
@@ -71,9 +67,9 @@ class TestOIDCPostinst:
             "tags": ["role::container-app"],
             "debian_section": "net",
             "architecture": "all",
-            "traefik": {
+            "routing": {
                 "subdomain": "fwd",
-                "auth": "forward_auth",
+                "auth": {"mode": "forward_auth"},
             },
         }
 
@@ -119,13 +115,9 @@ class TestOIDCPostrm:
             "tags": ["role::container-app"],
             "debian_section": "net",
             "architecture": "all",
-            "traefik": {
+            "routing": {
                 "subdomain": "oidc",
-                "auth": "oidc",
-                "oidc": {
-                    "client_name": "OIDC App",
-                    "redirect_path": "/callback",
-                },
+                "auth": {"mode": "oidc"},
             },
         }
 
@@ -167,12 +159,14 @@ class TestOIDCPostrm:
             "tags": ["role::container-app"],
             "debian_section": "net",
             "architecture": "all",
-            "traefik": {
+            "routing": {
                 "subdomain": "grafana",
-                "auth": "forward_auth",
-                "forward_auth": {
-                    "headers": {
-                        "Remote-User": "X-WEBAUTH-USER",
+                "auth": {
+                    "mode": "forward_auth",
+                    "forward_auth": {
+                        "headers": {
+                            "Remote-User": "X-WEBAUTH-USER",
+                        },
                     },
                 },
             },
@@ -261,13 +255,9 @@ class TestOIDCSystemdService:
             "tags": ["role::container-app"],
             "debian_section": "net",
             "architecture": "all",
-            "traefik": {
+            "routing": {
                 "subdomain": "oidc",
-                "auth": "oidc",
-                "oidc": {
-                    "client_name": "OIDC App",
-                    "redirect_path": "/callback",
-                },
+                "auth": {"mode": "oidc"},
             },
         }
 
@@ -309,9 +299,9 @@ class TestOIDCSystemdService:
             "tags": ["role::container-app"],
             "debian_section": "net",
             "architecture": "all",
-            "traefik": {
+            "routing": {
                 "subdomain": "fwd",
-                "auth": "forward_auth",
+                "auth": {"mode": "forward_auth"},
             },
         }
 
@@ -395,13 +385,9 @@ class TestOIDCRulesInstallation:
             "tags": ["role::container-app"],
             "debian_section": "net",
             "architecture": "all",
-            "traefik": {
+            "routing": {
                 "subdomain": "oidc",
-                "auth": "oidc",
-                "oidc": {
-                    "client_name": "OIDC App",
-                    "redirect_path": "/callback",
-                },
+                "auth": {"mode": "oidc"},
             },
         }
 
@@ -443,12 +429,14 @@ class TestOIDCRulesInstallation:
             "tags": ["role::container-app"],
             "debian_section": "net",
             "architecture": "all",
-            "traefik": {
+            "routing": {
                 "subdomain": "grafana",
-                "auth": "forward_auth",
-                "forward_auth": {
-                    "headers": {
-                        "Remote-User": "X-WEBAUTH-USER",
+                "auth": {
+                    "mode": "forward_auth",
+                    "forward_auth": {
+                        "headers": {
+                            "Remote-User": "X-WEBAUTH-USER",
+                        },
                     },
                 },
             },


### PR DESCRIPTION
## Summary
- Remove the deprecated `traefik` field from PackageMetadata schema
- Add `model_config=ConfigDict(extra='forbid')` to reject unknown fields (catches deprecated traefik usage)
- Update routing.py to remove traefik_config fallback logic
- Update traefik.py to only check routing config
- Update template_context.py to derive `is_oidc_app` from `routing.auth.mode`
- Update tests to use routing field instead of traefik

This is Phase 4 of the decoupled routing architecture (issue hatlabs/halos-distro#58).

**Breaking Change**: Apps must now use the `routing` field instead of the deprecated `traefik` field. Any metadata.yaml files using `traefik:` will fail validation with "Extra inputs are not permitted".

## Dependencies
This PR builds on:
- PR #159 (Phase 1: routing.yml generation) - must be merged first
- PR #160 (Phase 3: remove build-time Traefik labels) - must be merged first

## Test plan
- [x] All unit tests pass (450 passed, 17 skipped)
- [x] Lint and format checks pass
- [ ] Integration tests with halos-marine-containers (PR #76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)