### PR TITLE
fix(routing): use container port from docker-compose, not web_ui.port

### DIFF
--- a/src/generate_container_packages/template_context.py
+++ b/src/generate_container_packages/template_context.py
@@ -211,7 +211,9 @@ def build_context(app_def: AppDefinition) -> dict[str, Any]:
             has_custom_forward_auth = bool(fa_config.get("headers"))
         else:
             fa_config = routing.get("forward_auth", {})
-            has_custom_forward_auth = bool(fa_config.get("headers")) if fa_config else False
+            has_custom_forward_auth = (
+                bool(fa_config.get("headers")) if fa_config else False
+            )
 
     # Check if routing.yml should be generated
     has_routing = routing is not None or has_web_ui


### PR DESCRIPTION
## Summary

For container networking, the routing.yml port should be the container port from docker-compose port mappings, not web_ui.port which is often the host port.

### Problem

Grafana with docker-compose ports: `["3001:3000"]`:
- Before: routing.yml generated `port: 3001` (host port from web_ui.port)
- After: routing.yml generates `port: 3000` (container port from docker-compose)

This caused Traefik to connect to the wrong port since it runs on the Docker network where containers listen on their internal ports.

### Solution

- Added `_extract_container_port()` function to routing.py (same logic as traefik.py)
- Updated `_get_port()` to prefer container port from docker-compose, falling back to web_ui.port
- Added comprehensive tests for various port formats

### Test plan

- [x] All 798 tests pass
- [x] Lint and format checks pass
- [x] Type checks pass
- [ ] Integration test on device with updated packages

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)