### PR TITLE
fix(registry): use correct protocol and handle host network for ping_url

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -272,3 +272,24 @@ class TestGenerateRegistryToml:
 
         assert result is not None
         assert "ping_url" not in result
+
+    def test_ping_url_uses_https_when_configured(self, minimal_metadata, minimal_compose):
+        """Test ping_url uses HTTPS when web_ui.protocol is https."""
+        minimal_metadata["web_ui"]["protocol"] = "https"
+        minimal_metadata["web_ui"]["port"] = 3001
+        result = generate_registry_toml(
+            minimal_metadata, minimal_compose, self.TEST_HOSTNAME
+        )
+
+        assert result is not None
+        assert 'ping_url = "https://test-app:3001/"' in result
+
+    def test_ping_url_uses_host_docker_internal_for_host_network(
+        self, minimal_metadata
+    ):
+        """Test ping_url uses host.docker.internal for host network containers."""
+        compose = {"services": {"test-app": {"image": "test:latest", "network_mode": "host"}}}
+        result = generate_registry_toml(minimal_metadata, compose, self.TEST_HOSTNAME)
+
+        assert result is not None
+        assert 'ping_url = "http://host.docker.internal:8080/"' in result


### PR DESCRIPTION
## Summary
- Use `web_ui.protocol` for ping_url instead of always using HTTP (fixes OpenCPN which uses HTTPS internally)
- Detect `network_mode: host` in docker-compose and use `host.docker.internal` instead of container name (fixes Signal K which uses host networking)

## Problem
- OpenCPN: ping was failing with "400 Bad Request - HTTP sent to HTTPS port" because ping_url used HTTP but container uses HTTPS
- Signal K: ping was failing with "bad address" because it uses host networking and isn't on the Docker network

## Test plan
- [x] Added unit tests for HTTPS protocol handling
- [x] Added unit tests for host network detection
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)