### PR TITLE
docs: fix version bump workflow documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,11 @@ Note: Same .deb binary (0.2.0-N) is used for both pre-release and stable tags
 # Bump major version (0.2.0 -> 1.0.0)
 ./run bumpversion major
 
-# Commit the changes
-git add VERSION pyproject.toml src/generate_container_packages/__init__.py
-git commit -m "chore: bump version to $(cat VERSION)"
+# Push the automatically created commit
 git push origin main
 ```
+
+**Note:** The working directory must be clean before bumping. bumpversion automatically commits the version change (configured with `commit = True` in `.bumpversion.cfg`).
 
 **What happens automatically:**
 1. CI reads VERSION file


### PR DESCRIPTION
## Summary
- Remove incorrect manual `git add`/`git commit` instructions from version bump workflow
- bumpversion is configured with `commit = True`, so it automatically creates the commit
- Only `git push` is needed after bumping
- Add note explaining the auto-commit behavior and clean working directory requirement

Fixes #178

## Test plan
- [x] Verify `.bumpversion.cfg` has `commit = True`
- [ ] Documentation is clear and matches actual workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)