### PR TITLE
fix: install assets to assets/ subdirectory to match docker-compose paths

### DIFF
--- a/src/generate_container_packages/templates/debian/rules.j2
+++ b/src/generate_container_packages/templates/debian/rules.j2
@@ -29,9 +29,10 @@ override_dh_auto_install:
 
 {% if has_assets %}
 	# Install assets (755 for executables, 644 for regular files)
+	# Assets are installed under assets/ to preserve directory structure
 {% for asset in asset_files %}
 	install -D -m {{ '755' if asset.executable else '644' }} assets/{{ asset.path }} \
-		debian/{{ package.name }}/{{ paths.lib }}/{{ asset.path }}
+		debian/{{ package.name }}/{{ paths.lib }}/assets/{{ asset.path }}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
## Summary

- Fixes assets being installed directly to the package lib directory instead of under the `assets/` subdirectory
- This caused docker-compose.yml files that reference `./assets/<file>` to fail because the file was at `./<file>` instead
- Adds regression test to prevent this issue from recurring

## Root Cause

The debian/rules.j2 template installed assets to `{paths.lib}/{asset.path}` but should have been `{paths.lib}/assets/{asset.path}` to preserve the directory structure.

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass
- [x] New regression test added and passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)