### PR TITLE
fix(ci): wrap long changelog lines for lintian; clear pre-existing ty errors

### DIFF
--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -53,15 +53,29 @@ MAINTAINER_EMAIL="${MAINTAINER_EMAIL:-matti.airas@hatlabs.fi}"
 # Date in RFC 2822 format
 DATE=$(date -R)
 
-# Get recent changes from git log
-# Get commits since last published release tag
-LAST_TAG=$(git tag -l "v*" --sort=-version:refname | grep -v "~pre" | head -n1 || echo "")
+# Fold commit subjects into changelog bullets wrapped at 80 columns. lintian's
+# debian-changelog-line-too-long warning is fatal in the release build
+# (--fail-on warning), and conventional-commit subjects can exceed the limit
+# once the "  * " prefix is added.
+wrap_changes() {
+    while IFS= read -r subject; do
+        [ -z "$subject" ] && continue
+        printf '%s\n' "$subject" \
+            | fold -s -w 76 \
+            | sed -e 's/[[:space:]]*$//' -e '1s/^/  * /' -e '1!s/^/    /'
+    done
+}
 
+# Get commits since last published (non-pre-release) tag.
+LAST_TAG=$(git tag -l "v*" --sort=-version:refname | grep -v "_pre" | head -n1 || echo "")
+
+# tformat (not format) terminates every subject with a newline so the read
+# loop in wrap_changes does not drop the last commit.
 if [ -n "$LAST_TAG" ]; then
-    CHANGES=$(git log "${LAST_TAG}"..HEAD --pretty=format:"  * %s" --no-merges || echo "  * Build ${REVISION}")
+    CHANGES=$(git log "${LAST_TAG}"..HEAD --pretty=tformat:"%s" --no-merges -- | wrap_changes)
 else
     # No previous tags, use recent commits
-    CHANGES=$(git log -10 --pretty=format:"  * %s" --no-merges || echo "  * Build ${REVISION}")
+    CHANGES=$(git log -10 --pretty=tformat:"%s" --no-merges | wrap_changes)
 fi
 
 # If no changes (shouldn't happen), use a default message

--- a/src/generate_container_packages/converters/casaos/transformer.py
+++ b/src/generate_container_packages/converters/casaos/transformer.py
@@ -735,7 +735,7 @@ class MetadataTransformer:
                     # Transform host path
                     transformed_host = self._transform_path(volume.host, casaos_app.id)
 
-                    volume_def = {
+                    volume_def: dict[str, Any] = {
                         "type": "bind",
                         "source": transformed_host,
                         "target": volume.container,

--- a/src/generate_container_packages/routing.py
+++ b/src/generate_container_packages/routing.py
@@ -72,23 +72,22 @@ def generate_routing_yml(
     if scheme != "http":
         backend_config["scheme"] = scheme
 
+    auth_config: dict[str, Any] = {"mode": auth_mode}
+    # Add forward_auth headers if present
+    if forward_auth_headers:
+        auth_config["forward_auth"] = {"headers": forward_auth_headers}
+
     routing_data: dict[str, Any] = {
         "app_id": app_id,
         "package_name": package_name,
         "routing": {
             "backend": backend_config,
         },
-        "auth": {
-            "mode": auth_mode,
-        },
+        "auth": auth_config,
         "network": {
             "join_proxy_network": not is_host_network,
         },
     }
-
-    # Add forward_auth headers if present
-    if forward_auth_headers:
-        routing_data["auth"]["forward_auth"] = {"headers": forward_auth_headers}
 
     # Generate YAML with header comment
     header = f"""# Generic routing declaration for {app_id}


### PR DESCRIPTION
## What

Fix the red main CI from #208's merge, and clear the two pre-existing `ty` errors while here.

## Why

The release build (shared-workflows `build-release.yml`) regenerates `debian/changelog` from commit subjects and runs `lintian --fail-on error,warning`. The local `.github/scripts/generate-changelog.sh` prefixed each subject with `  * ` but never wrapped, so a subject over ~76 chars overflows lintian's 80-column limit and fails the build. #208 had two such subjects, so the `0.7.0` auto-release failed at the lintian step (before any tag was created — revision stays at 1).

This didn't affect downstream consumers (they build c-p-t from the git source, not the `.deb`), but it left main red with no release artifact.

## Changes

- **`fix(ci)`** — port the `wrap_changes` helper the shared-workflows fallback already uses: `fold -s -w 76` each subject with a hanging `    ` indent for continuation lines. Also fixes a stale `grep -v "~pre"` → `_pre` (tags use the underscore suffix per DEP-14), so pre-release tags are correctly excluded from the since-last-tag range. CI/tooling only — no version bump (`.github/` is excluded from the version-bump gate; VERSION is already ahead of stable).
- **`fix(types)`** — annotate two dict literals as `dict[str, Any]` that `ty` inferred as `dict[str, str]` from their string-only initial entries and then had a non-str value assigned (`forward_auth` dict in `routing.py`, `read_only` bool in the CasaOS transformer). Clears the long-standing `ty` diagnostics so `uvx ty check src/` is fully green. Bundled at maintainer request.

## Verification

- `uvx ty check src/` → All checks passed (was 2 diagnostics).
- `uv run pytest -m "not install"` → 586 passed / 1 skipped. Lint + format clean.
- Ran `generate-changelog.sh --upstream 0.7.0 --revision 2` locally: long subjects wrap, no line exceeds 80 columns.

After merge, the next main build regenerates the wrapped changelog and produces `container-packaging-tools 0.7.0-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
