### PR TITLE
feat: Declarative OIDC enablement capability (Plan B Units 1-4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,34 @@ Hook contract — available when `app-prestart.sh` runs:
 
 Prefer build-time `default-data/` for static seed config; reserve the hook for logic that genuinely needs runtime context.
 
+### Declarative OIDC (native-OAuth apps)
+
+An app that authenticates users via Authelia as its own OIDC client (native OAuth — e.g. Grafana, Signal K) declares it under `routing`, instead of hand-writing the lifecycle in a prestart:
+
+```yaml
+routing:
+  auth:
+    mode: oidc                       # no Traefik edge gate; wires the Authelia client scaffolding
+    oidc:
+      client_name: Grafana           # client_id defaults to app_id
+      scopes: [openid, profile, email, groups]
+      consent_mode: implicit
+      token_endpoint_auth_method: client_secret_basic   # or client_secret_post
+      redirect:
+        style: port                  # port → :${EXTERNAL_PORT}<path>; path → <path>
+        path: /login/generic_oauth
+      env:                           # container env var -> resolved source
+        GRAFANA_OIDC_CLIENT_SECRET: secret
+        HALOS_EXTERNAL_PORT: external_port
+```
+
+`mode: oidc` adds no edge gating (the app does its own OAuth) but makes `is_oidc_app` true, which drives the existing scaffolding: `postinst` provisions the client secret once (mode `600`), `service.j2` orders the unit `After=halos-authelia-container.service`, and `postrm` removes the snippet on purge. The generated prestart then resolves the external port (for `style: port`), appends the mapped `env` vars to `runtime.env`, and writes the Authelia client snippet to `/etc/halos/oidc-clients.d/<client_id>.yml`. `env` sources: `secret` (the client secret value), `issuer` (`https://${HALOS_DOMAIN}/sso`), `redirect` (computed redirect URI), `external_port`, `client_id`. App-specific extras (e.g. Signal K's `EXTERNALHOST`) stay in the `app-prestart.sh` hook.
+
+**Threat model:**
+- The client secret is generated once by `postinst` (root, mode `600`) and exposed to the container via `runtime.env` (mode `600`) — env-var delivery, as before.
+- `redirect_uris` carry the literal `${HALOS_DOMAIN}` token, which the core Authelia merger expands to one URI per DNS hostname in `/etc/halos/hostnames.conf`. **`hostnames.conf` is the redirect allow-list trust anchor**; the generator relies on the loader's hostname validation and emits no redirect outside `${HALOS_DOMAIN}`. The external port is integer-validated before it reaches the snippet.
+- The merger hardcodes `public: false` and `authorization_policy: one_factor` for every client; an app needing a different policy (public client, step-up auth) is not expressible via this declarative path.
+
 ## Git Workflow Policy
 
 **Branch Workflow:** Never push to main directly - always use feature branches and PRs.

--- a/src/generate_container_packages/oidc_snippet.py
+++ b/src/generate_container_packages/oidc_snippet.py
@@ -1,0 +1,112 @@
+"""Generate the prestart OIDC section from a declarative routing.auth.oidc config.
+
+For a native-OAuth app (`mode: oidc`), the generated prestart resolves the external
+port (port-based redirects), appends the container's OIDC env vars to runtime.env,
+and writes the Authelia client snippet to /etc/halos/oidc-clients.d/<client_id>.yml.
+
+The snippet is written at prestart time (not build time) because port-based redirect
+URIs embed the runtime-assigned port, and the core Authelia merger only expands the
+literal ${HALOS_DOMAIN} token — every other dynamic value must be fully resolved
+before the snippet is written. The client secret itself is generated once by postinst
+(is_oidc_app); the prestart only reads it.
+"""
+
+from typing import Any
+
+# Authelia issuer is always served at /sso by halos-core-containers.
+_ISSUER_URL = "https://${HALOS_DOMAIN}/sso"
+
+
+def _secret_file(package_name: str) -> str:
+    return f"/var/lib/container-apps/{package_name}/data/oidc-secret"
+
+
+def _redirect_uri(style: str, path: str, *, literal_domain: bool) -> str:
+    """Build a redirect URI.
+
+    literal_domain=True keeps ``${HALOS_DOMAIN}`` literal (for the Authelia snippet,
+    which the merger expands per hostname). False lets it expand at prestart write
+    time (for the container's own runtime.env value). The external port, when used,
+    is always the resolved shell value ``${EXTERNAL_PORT}``.
+    """
+    domain = r"\${HALOS_DOMAIN}" if literal_domain else "${HALOS_DOMAIN}"
+    port = ":${EXTERNAL_PORT}" if style == "port" else ""
+    return f"https://{domain}{port}{path}"
+
+
+def generate_oidc_section(
+    oidc: dict[str, Any], app_id: str, package_name: str
+) -> list[str]:
+    """Return the bash lines for the prestart OIDC section.
+
+    Args:
+        oidc: the ``routing.auth.oidc`` config dict.
+        app_id: app identifier (port-registry key and default client_id).
+        package_name: package name (used for the secret-file path).
+    """
+    client_id = oidc.get("client_id") or app_id
+    client_name = oidc["client_name"]
+    scopes = oidc.get("scopes", ["openid", "profile", "email", "groups"])
+    consent_mode = oidc.get("consent_mode", "implicit")
+    token_auth = oidc.get("token_endpoint_auth_method", "client_secret_basic")
+    redirect = oidc["redirect"]
+    style = redirect["style"]
+    path = redirect["path"]
+    env_map: dict[str, str] = oidc.get("env", {})
+
+    secret_file = _secret_file(package_name)
+
+    lines = [
+        "",
+        "# --- OIDC client registration (generated from routing.auth.oidc) ---",
+        f'OIDC_SECRET_FILE="{secret_file}"',
+    ]
+
+    # Port-based redirects need the runtime-assigned external port; validate it.
+    if style == "port":
+        lines.extend(
+            [
+                'EXTERNAL_PORT="$(grep "^'
+                + app_id
+                + '=" /etc/halos/port-registry 2>/dev/null | cut -d= -f2)"',
+                'case "$EXTERNAL_PORT" in',
+                '    ""|*[!0-9]*)',
+                f'        echo "ERROR: no valid external port for {app_id} in'
+                ' /etc/halos/port-registry" >&2',
+                "        exit 1",
+                "        ;;",
+                "esac",
+            ]
+        )
+
+    # Append the container's OIDC env vars (runtime.env, append-only).
+    source_values = {
+        "secret": '$(cat "$OIDC_SECRET_FILE")',
+        "issuer": _ISSUER_URL,
+        "redirect": _redirect_uri(style, path, literal_domain=False),
+        "external_port": "${EXTERNAL_PORT}",
+        "client_id": client_id,
+    }
+    for var_name, source in env_map.items():
+        value = source_values[source]
+        lines.append(f'echo "{var_name}={value}" >> "$RUNTIME_ENV"')
+
+    # Write the Authelia client snippet (literal ${HALOS_DOMAIN}; port resolved).
+    snippet_redirect = _redirect_uri(style, path, literal_domain=True)
+    lines.extend(
+        [
+            "mkdir -p /etc/halos/oidc-clients.d",
+            f"cat > /etc/halos/oidc-clients.d/{client_id}.yml << EOF",
+            f"client_id: {client_id}",
+            f"client_name: {client_name}",
+            f"client_secret_file: {secret_file}",
+            "redirect_uris:",
+            f"  - '{snippet_redirect}'",
+            f"scopes: [{', '.join(scopes)}]",
+            f"consent_mode: {consent_mode}",
+            f"token_endpoint_auth_method: {token_auth}",
+            "EOF",
+        ]
+    )
+
+    return lines

--- a/src/generate_container_packages/prestart.py
+++ b/src/generate_container_packages/prestart.py
@@ -114,9 +114,12 @@ def generate_prestart_script(app_def: AppDefinition) -> str:
     # resolves the external port (port-based redirects), appends the container's
     # OIDC env vars, and writes the Authelia client snippet.
     routing = metadata.get("routing") or {}
-    auth = routing.get("auth") if isinstance(routing, dict) else None
-    oidc = auth.get("oidc") if isinstance(auth, dict) else None
-    if oidc:
+    auth = routing.get("auth") if isinstance(routing, dict) else {}
+    auth = auth if isinstance(auth, dict) else {}
+    oidc = auth.get("oidc")
+    # Gate on mode == "oidc" to stay consistent with is_oidc_app, which drives the
+    # postinst secret provisioning and the Authelia unit ordering.
+    if auth.get("mode") == "oidc" and oidc:
         app_id = metadata.get("app_id", package_name)
         lines.extend(generate_oidc_section(oidc, app_id, package_name))
 

--- a/src/generate_container_packages/prestart.py
+++ b/src/generate_container_packages/prestart.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from generate_container_packages.labels import find_port_env_var
 from generate_container_packages.loader import AppDefinition
+from generate_container_packages.oidc_snippet import generate_oidc_section
 
 
 def get_homarr_url_expression(
@@ -107,6 +108,17 @@ def generate_prestart_script(app_def: AppDefinition) -> str:
                 'echo "HOMARR_URL=$HOMARR_URL" >> "$RUNTIME_ENV"',
             ]
         )
+
+    # OIDC client registration for native-OAuth apps (routing.auth.mode: oidc).
+    # The client secret is provisioned once by postinst; this section reads it,
+    # resolves the external port (port-based redirects), appends the container's
+    # OIDC env vars, and writes the Authelia client snippet.
+    routing = metadata.get("routing") or {}
+    auth = routing.get("auth") if isinstance(routing, dict) else None
+    oidc = auth.get("oidc") if isinstance(auth, dict) else None
+    if oidc:
+        app_id = metadata.get("app_id", package_name)
+        lines.extend(generate_oidc_section(oidc, app_id, package_name))
 
     # Source the optional app-specific hook last, with the framework scaffolding
     # (sourced env, $HALOS_DOMAIN, $RUNTIME_ENV) already in place. Absence is a

--- a/src/generate_container_packages/templates/debian/rules.j2
+++ b/src/generate_container_packages/templates/debian/rules.j2
@@ -55,12 +55,6 @@ override_dh_auto_install:
 		debian/{{ package.name }}/etc/halos/webapps.d/{{ package.name }}.toml
 {% endif %}
 
-{% if is_oidc_app %}
-	# Install OIDC client snippet for Authelia
-	install -D -m 644 oidc-client.yml \
-		debian/{{ package.name }}/etc/halos/oidc-clients.d/{{ package.app_id }}.yml
-{% endif %}
-
 {% if has_custom_forward_auth %}
 	# Install per-app ForwardAuth middleware for Traefik
 	install -D -m 644 traefik-middleware.yml \

--- a/src/schemas/metadata.py
+++ b/src/schemas/metadata.py
@@ -1,5 +1,6 @@
 """Pydantic models for validating metadata.yaml files."""
 
+import re
 import subprocess
 from typing import Literal
 
@@ -102,18 +103,14 @@ class OidcRedirect(BaseModel):
     style: Literal["path", "port"] = Field(
         description="Redirect URL shape: path-based or external-port-based",
     )
+    # Constrained to a URL-path charset: the value is interpolated into the
+    # generated prestart's heredoc/echo lines, so shell/heredoc metacharacters
+    # (quotes, $, backticks, newlines) must not be expressible.
     path: str = Field(
         min_length=1,
-        description="Callback path (must start with /)",
+        pattern=r"^/[A-Za-z0-9._~/-]*$",
+        description="Callback path (absolute, URL-path characters only)",
     )
-
-    @field_validator("path")
-    @classmethod
-    def validate_path_absolute(cls, v: str) -> str:
-        """Ensure the callback path is absolute."""
-        if not v.startswith("/"):
-            raise ValueError(f"redirect path must start with '/', got: '{v}'")
-        return v
 
 
 # Sources the generator can resolve into a container env var for an OIDC app.
@@ -128,12 +125,17 @@ class OidcConfig(BaseModel):
     container env vars the app consumes — no hand-written prestart needed.
     """
 
+    # client_id flows into a file path and a grep pattern; client_name into a
+    # heredoc body. Both are interpolated into root-executed generated bash, so
+    # they are charset-constrained to block injection / path traversal.
     client_id: str | None = Field(
         default=None,
+        pattern=r"^[a-z0-9][a-z0-9-]*$",
         description="OIDC client id (defaults to the app_id when omitted)",
     )
     client_name: str = Field(
         min_length=1,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9 ._-]*$",
         description="Human-readable client name shown in consent screens",
     )
     scopes: list[str] = Field(
@@ -145,11 +147,11 @@ class OidcConfig(BaseModel):
         default="implicit",
         description="Authelia consent mode for this client",
     )
-    token_endpoint_auth_method: Literal[
-        "client_secret_basic", "client_secret_post"
-    ] = Field(
-        default="client_secret_basic",
-        description="Token endpoint auth method the app's OIDC library uses",
+    token_endpoint_auth_method: Literal["client_secret_basic", "client_secret_post"] = (
+        Field(
+            default="client_secret_basic",
+            description="Token endpoint auth method the app's OIDC library uses",
+        )
     )
     redirect: OidcRedirect = Field(
         description="OAuth2 callback descriptor",
@@ -163,6 +165,37 @@ class OidcConfig(BaseModel):
             "client_id."
         ),
     )
+
+    @field_validator("scopes")
+    @classmethod
+    def validate_scopes(cls, v: list[str]) -> list[str]:
+        """Scopes are interpolated into the snippet's scope list; keep them simple."""
+        for scope in v:
+            if not re.match(r"^[a-z0-9_]+$", scope):
+                raise ValueError(f"invalid OIDC scope: '{scope}'")
+        return v
+
+    @field_validator("env")
+    @classmethod
+    def validate_env_var_names(
+        cls, v: dict[str, OidcEnvSource]
+    ) -> dict[str, OidcEnvSource]:
+        """Env var names are echoed into runtime.env by generated bash; require
+        the POSIX env-name charset so they cannot break out of the echo line."""
+        for name in v:
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
+                raise ValueError(f"invalid OIDC env var name: '{name}'")
+        return v
+
+    @model_validator(mode="after")
+    def validate_external_port_requires_port_style(self) -> "OidcConfig":
+        """An env mapping to external_port only resolves when the redirect is
+        port-based (the port is otherwise never assigned in the prestart)."""
+        if "external_port" in self.env.values() and self.redirect.style != "port":
+            raise ValueError(
+                "env source 'external_port' requires redirect.style 'port'"
+            )
+        return self
 
 
 class RoutingAuth(BaseModel):
@@ -187,10 +220,15 @@ class RoutingAuth(BaseModel):
     )
 
     @model_validator(mode="after")
-    def validate_oidc_present_for_oidc_mode(self) -> "RoutingAuth":
-        """`mode: oidc` requires an `oidc` config block."""
+    def validate_oidc_matches_mode(self) -> "RoutingAuth":
+        """`oidc` and `mode: oidc` must agree in both directions, so the prestart
+        OIDC section and the is_oidc_app scaffolding (postinst secret-gen, Authelia
+        ordering) can never diverge — an oidc block under another mode would write a
+        snippet whose secret is never provisioned."""
         if self.mode == "oidc" and self.oidc is None:
             raise ValueError("routing.auth.oidc is required when mode='oidc'")
+        if self.mode != "oidc" and self.oidc is not None:
+            raise ValueError("routing.auth.oidc is only valid with mode='oidc'")
         return self
 
 

--- a/src/schemas/metadata.py
+++ b/src/schemas/metadata.py
@@ -91,6 +91,80 @@ class TraefikForwardAuth(BaseModel):
 # Generic, proxy-agnostic routing configuration models
 
 
+class OidcRedirect(BaseModel):
+    """OAuth2 redirect (callback) descriptor for a native-OIDC app.
+
+    `path` style emits `https://${HALOS_DOMAIN}<path>`; `port` style emits
+    `https://${HALOS_DOMAIN}:<external_port><path>`, where the external port is
+    resolved at runtime from the routing port registry.
+    """
+
+    style: Literal["path", "port"] = Field(
+        description="Redirect URL shape: path-based or external-port-based",
+    )
+    path: str = Field(
+        min_length=1,
+        description="Callback path (must start with /)",
+    )
+
+    @field_validator("path")
+    @classmethod
+    def validate_path_absolute(cls, v: str) -> str:
+        """Ensure the callback path is absolute."""
+        if not v.startswith("/"):
+            raise ValueError(f"redirect path must start with '/', got: '{v}'")
+        return v
+
+
+# Sources the generator can resolve into a container env var for an OIDC app.
+OidcEnvSource = Literal["secret", "issuer", "redirect", "external_port", "client_id"]
+
+
+class OidcConfig(BaseModel):
+    """Declarative OIDC client config for a native-OAuth app.
+
+    Present under `routing.auth.oidc` with `mode: oidc`. The generator turns this
+    into the Authelia client snippet, the client-secret provisioning, and the
+    container env vars the app consumes — no hand-written prestart needed.
+    """
+
+    client_id: str | None = Field(
+        default=None,
+        description="OIDC client id (defaults to the app_id when omitted)",
+    )
+    client_name: str = Field(
+        min_length=1,
+        description="Human-readable client name shown in consent screens",
+    )
+    scopes: list[str] = Field(
+        default=["openid", "profile", "email", "groups"],
+        min_length=1,
+        description="OAuth2 scopes to request",
+    )
+    consent_mode: Literal["implicit", "explicit", "pre-configured"] = Field(
+        default="implicit",
+        description="Authelia consent mode for this client",
+    )
+    token_endpoint_auth_method: Literal[
+        "client_secret_basic", "client_secret_post"
+    ] = Field(
+        default="client_secret_basic",
+        description="Token endpoint auth method the app's OIDC library uses",
+    )
+    redirect: OidcRedirect = Field(
+        description="OAuth2 callback descriptor",
+    )
+    env: dict[str, OidcEnvSource] = Field(
+        default_factory=dict,
+        description=(
+            "Map of container env var name -> resolved source. Sources: secret "
+            "(client secret value), issuer (Authelia issuer URL), redirect "
+            "(computed redirect URI), external_port (resolved routing port), "
+            "client_id."
+        ),
+    )
+
+
 class RoutingAuth(BaseModel):
     """Authentication configuration for routing.
 
@@ -107,6 +181,17 @@ class RoutingAuth(BaseModel):
         default=None,
         description="Custom forward auth configuration with header mappings",
     )
+    oidc: OidcConfig | None = Field(
+        default=None,
+        description="OIDC client config for native-OAuth apps (with mode: oidc)",
+    )
+
+    @model_validator(mode="after")
+    def validate_oidc_present_for_oidc_mode(self) -> "RoutingAuth":
+        """`mode: oidc` requires an `oidc` config block."""
+        if self.mode == "oidc" and self.oidc is None:
+            raise ValueError("routing.auth.oidc is required when mode='oidc'")
+        return self
 
 
 class RoutingConfig(BaseModel):

--- a/tests/test_oidc_config.py
+++ b/tests/test_oidc_config.py
@@ -64,9 +64,8 @@ class TestOidcConfig:
         assert "client_name" in str(exc.value)
 
     def test_redirect_path_must_be_absolute(self) -> None:
-        with pytest.raises(ValidationError) as exc:
+        with pytest.raises(ValidationError):
             OidcRedirect(style="path", path="login/cb")
-        assert "must start with '/'" in str(exc.value)
 
     def test_invalid_redirect_style_errors(self) -> None:
         with pytest.raises(ValidationError):
@@ -79,6 +78,57 @@ class TestOidcConfig:
                 redirect=OidcRedirect(style="path", path="/cb"),
                 env={"FOO": "not_a_source"},  # type: ignore[dict-item]
             )
+
+
+class TestOidcInjectionHardening:
+    """Charset constraints block injection into the generated (root-run) bash."""
+
+    def _cfg(self, **over):
+        base = {
+            "client_name": "App",
+            "redirect": OidcRedirect(style="path", path="/cb"),
+        }
+        base.update(over)
+        return OidcConfig(**base)
+
+    def test_client_name_rejects_heredoc_breakout(self) -> None:
+        # newline + EOF would terminate the snippet heredoc early -> root RCE
+        with pytest.raises(ValidationError):
+            self._cfg(client_name="App\nEOF\nrm -rf /\ncat << EOF")
+
+    def test_client_name_rejects_command_substitution(self) -> None:
+        with pytest.raises(ValidationError):
+            self._cfg(client_name="App$(id)")
+
+    def test_client_id_rejects_path_traversal(self) -> None:
+        with pytest.raises(ValidationError):
+            self._cfg(client_id="../../etc/cron.d/x")
+
+    def test_env_var_name_rejects_command_substitution(self) -> None:
+        # key is echoed into runtime.env inside double quotes
+        with pytest.raises(ValidationError):
+            self._cfg(env={'X";$(id);echo "': "secret"})
+
+    def test_scope_rejects_metacharacters(self) -> None:
+        with pytest.raises(ValidationError):
+            self._cfg(scopes=["openid", "evil; rm -rf /"])
+
+    def test_redirect_path_rejects_quote(self) -> None:
+        with pytest.raises(ValidationError):
+            OidcRedirect(style="path", path="/cb'; touch /tmp/x; '")
+
+    def test_external_port_source_requires_port_style(self) -> None:
+        with pytest.raises(ValidationError):
+            self._cfg(
+                redirect=OidcRedirect(style="path", path="/cb"),
+                env={"PORT": "external_port"},
+            )
+
+    def test_valid_consumer_values_pass(self) -> None:
+        # The real consumers' values must still validate
+        self._cfg(client_name="Signal K Server")
+        self._cfg(client_id="signalk", client_name="Signal K Server")
+        OidcRedirect(style="path", path="/signalk-server/signalk/v1/auth/oidc/callback")
 
 
 class TestRoutingAuthOidc:
@@ -99,6 +149,19 @@ class TestRoutingAuthOidc:
         )
         assert auth.mode == "oidc"
         assert auth.oidc is not None
+
+    def test_oidc_block_requires_oidc_mode(self) -> None:
+        # An oidc block under mode != oidc would write a snippet whose secret
+        # postinst never provisions (is_oidc_app gates on mode == oidc).
+        with pytest.raises(ValidationError) as exc:
+            RoutingAuth(
+                mode="none",
+                oidc=OidcConfig(
+                    client_name="App",
+                    redirect=OidcRedirect(style="path", path="/cb"),
+                ),
+            )
+        assert "only valid with mode='oidc'" in str(exc.value)
 
     def test_mode_none_without_oidc_unchanged(self) -> None:
         auth = RoutingAuth(mode="none")

--- a/tests/test_oidc_config.py
+++ b/tests/test_oidc_config.py
@@ -1,0 +1,110 @@
+"""Tests for the declarative OIDC client config (routing.auth.oidc)."""
+
+import pytest
+from pydantic import ValidationError
+
+from schemas.metadata import OidcConfig, OidcRedirect, RoutingAuth
+
+
+class TestOidcConfig:
+    """OidcConfig must round-trip both real consumers (grafana, signalk)."""
+
+    def test_grafana_shape_port_based(self) -> None:
+        """Grafana: port-based redirect, client_secret_basic, secret+external_port env."""
+        cfg = OidcConfig(
+            client_name="Grafana",
+            token_endpoint_auth_method="client_secret_basic",
+            redirect=OidcRedirect(style="port", path="/login/generic_oauth"),
+            env={
+                "GRAFANA_OIDC_CLIENT_SECRET": "secret",
+                "HALOS_EXTERNAL_PORT": "external_port",
+            },
+        )
+        assert cfg.redirect.style == "port"
+        assert cfg.token_endpoint_auth_method == "client_secret_basic"
+        assert cfg.env["HALOS_EXTERNAL_PORT"] == "external_port"
+        # client_id defaults to None (generator fills from app_id)
+        assert cfg.client_id is None
+        # scopes default includes groups (both consumers need it)
+        assert "groups" in cfg.scopes
+
+    def test_signalk_shape_path_based(self) -> None:
+        """Signal K: path-based redirect, client_secret_post, issuer/redirect/secret env."""
+        cfg = OidcConfig(
+            client_name="Signal K Server",
+            token_endpoint_auth_method="client_secret_post",
+            redirect=OidcRedirect(
+                style="path",
+                path="/signalk-server/signalk/v1/auth/oidc/callback",
+            ),
+            env={
+                "SIGNALK_OIDC_CLIENT_SECRET": "secret",
+                "SIGNALK_OIDC_ISSUER": "issuer",
+                "SIGNALK_OIDC_REDIRECT_URI": "redirect",
+            },
+        )
+        assert cfg.redirect.style == "path"
+        assert cfg.token_endpoint_auth_method == "client_secret_post"
+        assert set(cfg.env.values()) == {"secret", "issuer", "redirect"}
+
+    def test_defaults(self) -> None:
+        """Optional fields default sensibly."""
+        cfg = OidcConfig(
+            client_name="App",
+            redirect=OidcRedirect(style="path", path="/cb"),
+        )
+        assert cfg.scopes == ["openid", "profile", "email", "groups"]
+        assert cfg.consent_mode == "implicit"
+        assert cfg.token_endpoint_auth_method == "client_secret_basic"
+        assert cfg.env == {}
+
+    def test_missing_client_name_errors(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            OidcConfig(redirect=OidcRedirect(style="path", path="/cb"))  # type: ignore[call-arg]
+        assert "client_name" in str(exc.value)
+
+    def test_redirect_path_must_be_absolute(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            OidcRedirect(style="path", path="login/cb")
+        assert "must start with '/'" in str(exc.value)
+
+    def test_invalid_redirect_style_errors(self) -> None:
+        with pytest.raises(ValidationError):
+            OidcRedirect(style="subdomain", path="/cb")  # type: ignore[arg-type]
+
+    def test_invalid_env_source_errors(self) -> None:
+        with pytest.raises(ValidationError):
+            OidcConfig(
+                client_name="App",
+                redirect=OidcRedirect(style="path", path="/cb"),
+                env={"FOO": "not_a_source"},  # type: ignore[dict-item]
+            )
+
+
+class TestRoutingAuthOidc:
+    """RoutingAuth wires oidc and enforces it for mode: oidc."""
+
+    def test_mode_oidc_requires_oidc_block(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            RoutingAuth(mode="oidc")
+        assert "routing.auth.oidc is required" in str(exc.value)
+
+    def test_mode_oidc_with_oidc_block_valid(self) -> None:
+        auth = RoutingAuth(
+            mode="oidc",
+            oidc=OidcConfig(
+                client_name="Grafana",
+                redirect=OidcRedirect(style="port", path="/login/generic_oauth"),
+            ),
+        )
+        assert auth.mode == "oidc"
+        assert auth.oidc is not None
+
+    def test_mode_none_without_oidc_unchanged(self) -> None:
+        auth = RoutingAuth(mode="none")
+        assert auth.oidc is None
+
+    def test_mode_forward_auth_default_unaffected(self) -> None:
+        auth = RoutingAuth()
+        assert auth.mode == "forward_auth"
+        assert auth.oidc is None

--- a/tests/test_oidc_snippet.py
+++ b/tests/test_oidc_snippet.py
@@ -1,0 +1,105 @@
+"""Tests for the prestart OIDC section generator (generate_oidc_section)."""
+
+from generate_container_packages.oidc_snippet import generate_oidc_section
+
+GRAFANA_OIDC = {
+    "client_name": "Grafana",
+    "token_endpoint_auth_method": "client_secret_basic",
+    "redirect": {"style": "port", "path": "/login/generic_oauth"},
+    "env": {
+        "GRAFANA_OIDC_CLIENT_SECRET": "secret",
+        "HALOS_EXTERNAL_PORT": "external_port",
+    },
+}
+
+SIGNALK_OIDC = {
+    "client_name": "Signal K Server",
+    "token_endpoint_auth_method": "client_secret_post",
+    "redirect": {
+        "style": "path",
+        "path": "/signalk-server/signalk/v1/auth/oidc/callback",
+    },
+    "env": {
+        "SIGNALK_OIDC_CLIENT_SECRET": "secret",
+        "SIGNALK_OIDC_ISSUER": "issuer",
+        "SIGNALK_OIDC_REDIRECT_URI": "redirect",
+    },
+}
+
+
+def _script(oidc, app_id, package_name="pkg-container"):
+    return "\n".join(generate_oidc_section(oidc, app_id, package_name))
+
+
+class TestPortBasedGrafana:
+    def test_resolves_and_validates_external_port(self):
+        s = _script(GRAFANA_OIDC, "grafana")
+        # reads the registry keyed by app_id
+        assert 'grep "^grafana=" /etc/halos/port-registry' in s
+        # rejects empty / non-integer
+        assert "*[!0-9]*)" in s
+        assert "exit 1" in s
+
+    def test_env_map_appends_secret_and_port(self):
+        s = _script(GRAFANA_OIDC, "grafana")
+        assert (
+            'echo "GRAFANA_OIDC_CLIENT_SECRET=$(cat "$OIDC_SECRET_FILE")" >> "$RUNTIME_ENV"'
+            in s
+        )
+        assert 'echo "HALOS_EXTERNAL_PORT=${EXTERNAL_PORT}" >> "$RUNTIME_ENV"' in s
+
+    def test_snippet_port_based_redirect(self):
+        s = _script(GRAFANA_OIDC, "grafana", "marine-grafana-container")
+        # unquoted heredoc so ${EXTERNAL_PORT} expands at write time; HALOS_DOMAIN stays literal
+        assert "cat > /etc/halos/oidc-clients.d/grafana.yml << EOF" in s
+        assert (
+            r"  - 'https://\${HALOS_DOMAIN}:${EXTERNAL_PORT}/login/generic_oauth'" in s
+        )
+        assert (
+            "client_secret_file: /var/lib/container-apps/marine-grafana-container/data/oidc-secret"
+            in s
+        )
+        assert "scopes: [openid, profile, email, groups]" in s
+        assert "token_endpoint_auth_method: client_secret_basic" in s
+
+
+class TestPathBasedSignalk:
+    def test_no_port_resolution(self):
+        s = _script(SIGNALK_OIDC, "signalk-server")
+        assert "port-registry" not in s
+        assert "EXTERNAL_PORT" not in s
+
+    def test_env_map_issuer_and_redirect_expand_domain(self):
+        s = _script(SIGNALK_OIDC, "signalk-server")
+        # In runtime.env, HALOS_DOMAIN must EXPAND (container needs the real value)
+        assert (
+            'echo "SIGNALK_OIDC_ISSUER=https://${HALOS_DOMAIN}/sso" >> "$RUNTIME_ENV"'
+            in s
+        )
+        assert (
+            'echo "SIGNALK_OIDC_REDIRECT_URI=https://${HALOS_DOMAIN}'
+            '/signalk-server/signalk/v1/auth/oidc/callback" >> "$RUNTIME_ENV"' in s
+        )
+
+    def test_snippet_path_based_redirect_literal_domain_no_port(self):
+        s = _script(SIGNALK_OIDC, "signalk-server")
+        # snippet keeps ${HALOS_DOMAIN} literal (merger expands), no port
+        assert (
+            r"  - 'https://\${HALOS_DOMAIN}/signalk-server/signalk/v1/auth/oidc/callback'"
+            in s
+        )
+        assert ":${EXTERNAL_PORT}" not in s
+        assert "token_endpoint_auth_method: client_secret_post" in s
+
+
+class TestClientId:
+    def test_client_id_defaults_to_app_id(self):
+        s = _script(SIGNALK_OIDC, "signalk-server")
+        assert "client_id: signalk-server" in s
+        assert "oidc-clients.d/signalk-server.yml" in s
+
+    def test_explicit_client_id_overrides(self):
+        oidc = {**SIGNALK_OIDC, "client_id": "signalk"}
+        s = _script(oidc, "signalk-server")
+        assert "client_id: signalk" in s
+        assert "oidc-clients.d/signalk.yml" in s

--- a/tests/test_oidc_snippet.py
+++ b/tests/test_oidc_snippet.py
@@ -103,3 +103,23 @@ class TestClientId:
         s = _script(oidc, "signalk-server")
         assert "client_id: signalk" in s
         assert "oidc-clients.d/signalk.yml" in s
+
+
+class TestEnvSources:
+    def test_client_id_env_source_resolves(self):
+        oidc = {
+            "client_name": "App",
+            "redirect": {"style": "path", "path": "/cb"},
+            "env": {"APP_CLIENT_ID": "client_id"},
+        }
+        s = _script(oidc, "my-app", "my-app-container")
+        assert 'echo "APP_CLIENT_ID=my-app" >> "$RUNTIME_ENV"' in s
+
+    def test_issuer_env_source_resolves(self):
+        oidc = {
+            "client_name": "App",
+            "redirect": {"style": "path", "path": "/cb"},
+            "env": {"APP_ISSUER": "issuer"},
+        }
+        s = _script(oidc, "my-app")
+        assert 'echo "APP_ISSUER=https://${HALOS_DOMAIN}/sso" >> "$RUNTIME_ENV"' in s

--- a/tests/test_prestart.py
+++ b/tests/test_prestart.py
@@ -1,6 +1,10 @@
 """Unit tests for prestart script generation."""
 
+import shutil
+import subprocess
 from unittest import mock
+
+import pytest
 
 from generate_container_packages.loader import AppDefinition
 from generate_container_packages.prestart import (
@@ -264,3 +268,67 @@ class TestGeneratePrestartScript:
         # The hook is sourced after the LAST runtime.env write (not merely after
         # the RUNTIME_ENV declaration), so framework scaffolding is fully in place.
         assert script.rindex('>> "$RUNTIME_ENV"') < script.index(hook)
+
+
+class TestOidcSectionWiring:
+    """generate_prestart_script emits the OIDC section only for mode: oidc apps."""
+
+    def _oidc_app(self, *, app_id="grafana", with_app_id=True):
+        app_def = mock.Mock(spec=AppDefinition)
+        meta = {
+            "package_name": "marine-grafana-container",
+            "name": "Grafana",
+            "web_ui": {"enabled": True, "protocol": "http", "port": 3000},
+            "routing": {
+                "auth": {
+                    "mode": "oidc",
+                    "oidc": {
+                        "client_name": "Grafana",
+                        "token_endpoint_auth_method": "client_secret_basic",
+                        "redirect": {"style": "port", "path": "/login/generic_oauth"},
+                        "env": {
+                            "GRAFANA_OIDC_CLIENT_SECRET": "secret",
+                            "HALOS_EXTERNAL_PORT": "external_port",
+                        },
+                    },
+                }
+            },
+        }
+        if with_app_id:
+            meta["app_id"] = app_id
+        app_def.metadata = meta
+        return app_def
+
+    def test_oidc_app_emits_section(self):
+        script = generate_prestart_script(self._oidc_app())
+        assert "# --- OIDC client registration" in script
+        assert "cat > /etc/halos/oidc-clients.d/grafana.yml << EOF" in script
+        # the port-registry lookup keys on app_id
+        assert 'grep "^grafana=" /etc/halos/port-registry' in script
+
+    def test_app_id_falls_back_to_package_name(self):
+        script = generate_prestart_script(self._oidc_app(with_app_id=False))
+        # no app_id -> port-registry key and client_id use package_name
+        assert 'grep "^marine-grafana-container=" /etc/halos/port-registry' in script
+
+    def test_forward_auth_app_has_no_oidc_section(self):
+        app_def = mock.Mock(spec=AppDefinition)
+        app_def.metadata = {
+            "package_name": "test-app-container",
+            "name": "Test App",
+            "web_ui": {"enabled": True, "protocol": "http", "port": 8080},
+            "routing": {"auth": {"mode": "forward_auth"}},
+        }
+        script = generate_prestart_script(app_def)
+        assert "OIDC client registration" not in script
+        assert "oidc-clients.d" not in script
+
+    def test_generated_oidc_prestart_is_valid_bash(self):
+        """The assembled script (heredoc, case block, expansions) must parse."""
+        if shutil.which("bash") is None:
+            pytest.skip("bash not available")
+        script = generate_prestart_script(self._oidc_app())
+        result = subprocess.run(
+            ["bash", "-n"], input=script, text=True, capture_output=True
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_routing_schema.py
+++ b/tests/test_routing_schema.py
@@ -4,6 +4,8 @@ import pytest
 from pydantic import ValidationError
 
 from schemas.metadata import (
+    OidcConfig,
+    OidcRedirect,
     PackageMetadata,
     RoutingAuth,
     RoutingConfig,
@@ -19,10 +21,19 @@ class TestRoutingConfig:
         assert config.auth is None  # Default to None, will be forward_auth at runtime
 
     def test_auth_modes(self) -> None:
-        """All auth modes should be valid."""
-        for mode in ["forward_auth", "oidc", "none"]:
+        """forward_auth and none validate bare; oidc requires an oidc block."""
+        for mode in ["forward_auth", "none"]:
             auth = RoutingAuth(mode=mode)  # type: ignore[arg-type]
             assert auth.mode == mode
+
+        oidc_auth = RoutingAuth(
+            mode="oidc",
+            oidc=OidcConfig(
+                client_name="App",
+                redirect=OidcRedirect(style="path", path="/cb"),
+            ),
+        )
+        assert oidc_auth.mode == "oidc"
 
     def test_invalid_auth_mode(self) -> None:
         """Invalid auth mode should fail validation."""

--- a/tests/test_templates_oidc.py
+++ b/tests/test_templates_oidc.py
@@ -362,10 +362,12 @@ class TestOIDCSystemdService:
 
 
 class TestOIDCRulesInstallation:
-    """Tests for debian/rules OIDC file installation."""
+    """Tests for debian/rules OIDC handling."""
 
-    def test_oidc_app_installs_snippet(self, tmp_path):
-        """OIDC app rules should install OIDC client snippet."""
+    def test_oidc_app_does_not_install_snippet_at_build_time(self, tmp_path):
+        """The Authelia snippet is written by the prestart at runtime (the port
+        for port-based redirects is only known then), so rules must NOT install a
+        build-time oidc-client.yml."""
         metadata = {
             "name": "OIDC App",
             "app_id": "oidc-app",
@@ -403,9 +405,8 @@ class TestOIDCRulesInstallation:
         rules = output_dir / "debian" / "rules"
         content = rules.read_text()
 
-        # Verify OIDC snippet installation
-        assert "oidc-client.yml" in content
-        assert "/etc/halos/oidc-clients.d/oidc-app.yml" in content
+        # No build-time snippet install — the prestart writes it at runtime.
+        assert "oidc-client.yml" not in content
 
     def test_middleware_app_installs_middleware(self, tmp_path):
         """Forward auth app with custom headers should install middleware."""


### PR DESCRIPTION
## What & why

Makes OIDC enablement declarative (Plan B of the #207 series). grafana and signalk hand-roll ~80–180 lines of prestart each to register as Authelia OIDC clients (secret gen, port resolution, container env vars, client snippet) — the duplication that shipped the `HALOS_DOMAIN` bug (#177). Now an app declares `routing.auth.mode: oidc` + a `routing.auth.oidc` block and the generator produces the lifecycle.

Builds on the composable prestart (#212, merged) and the legacy cleanup (#214, merged), so it lands on a clean slate.

## Approach (Option X)

`mode: oidc` is the native-OAuth contract: it adds **no** Traefik edge gate (`configure-container-routing` only chains Authelia middleware for `forward_auth`), but makes `is_oidc_app` true, reusing the existing scaffolding — `postinst` provisions the secret once (mode 600), `service.j2` orders `After=halos-authelia-container.service`, `postrm` cleans up. So OIDC client config lives under `routing.auth.oidc`, not an orthogonal stanza that would strand that scaffolding.

- **Schema** (`OidcConfig`): `client_name`, `scopes`, `consent_mode`, `token_endpoint_auth_method`, a discriminated `redirect {style: port|path, path}`, and a **free-form `env {container_var: source}`** map. The map is free-form because the two consumers differ: grafana needs only `secret` + `external_port` (derives its redirect from `GF_SERVER_ROOT_URL`); signalk needs `secret` + `issuer` + `redirect`. A fixed triad can't express both.
- **Prestart OIDC section**: resolves the external port (port-based, integer-validated from the registry), appends the mapped env vars to `runtime.env`, and writes the Authelia client snippet — at **prestart time** for all OIDC apps (the port-based redirect embeds the runtime port, and the merger only expands `${HALOS_DOMAIN}`). This removes the dead build-time `rules.j2` install entirely (one code path), resolving the dangling-install issue noted in #214's review.

## Verification
- 561 unit tests pass; `ruff`, `ruff format --check`, `uvx ty check src/` clean.
- The generated prestart is byte-checked against grafana (port-based, `client_secret_basic`) and signalk (path-based, `client_secret_post`) and `bash -n` valid — it reproduces their hand-rolled snippets/env, with literal `${HALOS_DOMAIN}` (merger expands) and the port resolved at write.
- No version bump: the 0.8.0 cycle is already open (CI walks `+N`).

## Threat model
Documented in `AGENTS.md`: secret is `postinst`-provisioned (root, 600) and env-delivered via `runtime.env` (600); `hostnames.conf` is the redirect allow-list trust anchor (generator emits literal `${HALOS_DOMAIN}` only, port integer-validated); the merger fixes `public: false` / `one_factor` (apps needing other policies are unsupported here).

## Scope
Plan B Units 1–4 (capability + docs). **Unit 5 (migrate grafana + signalk to the stanza) is deliberately not here** — it's the marine repo, and it merges with Plan A's avnav/influxdb migration in one coordinated `CONTAINER_TOOLS_REF` window after this releases (the rollout entanglement).

## Post-Deploy Monitoring & Validation
No production runtime impact from merging — changes generated package output, not a running service. Validation happens when grafana/signalk migrate (Unit 5, separate PR): on-device `tools/test-oidc-all.sh` for login/callback/SSO, and confirm the generated snippet matches today's hand-rolled one.

Part of #211.
