### PR TITLE
fix(systemd): bound Restart=always with a start-rate limit

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -499,6 +499,8 @@ Tag: {{ package.tags }}
 Description={{ service.description }}
 After=docker.service
 Requires=docker.service
+StartLimitIntervalSec=600
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -517,6 +519,8 @@ WantedBy=multi-user.target
 ```
 
 **Note**: Type=simple runs docker-compose in foreground mode, allowing systemd to properly manage the container lifecycle. Container logs are streamed to journal via stdout/stderr. Restart=always ensures the container restarts after both failures and clean exits (e.g., in-app restart requests), while `systemctl stop` still works correctly.
+
+**Note on StartLimit and recovery**: `Restart=always` alone makes a deterministically-failing `ExecStartPre` (the prestart, `configure-container-routing`, or an `app-prestart.sh` hook running under `set -e`) retry every `RestartSec` forever. `StartLimitIntervalSec=600` / `StartLimitBurst=5` bound this: 5 failed starts within 600s drive the unit to `failed` (~40s with `RestartSec=10`) instead of looping silently, while legitimate in-app restarts spaced further apart than `interval/burst` never accumulate. A unit that hits the start limit stays in `failed` and does **not** self-heal — recover with `systemctl reset-failed <package>.service && systemctl start <package>.service` after fixing the underlying cause. A package upgrade does not clear this state automatically (postinst reloads and enables but does not restart the unit).
 
 ## Path Conventions
 

--- a/src/generate_container_packages/templates/systemd/service.j2
+++ b/src/generate_container_packages/templates/systemd/service.j2
@@ -2,6 +2,15 @@
 Description={{ service.description }}
 After=docker.service
 Requires=docker.service
+# Bound Restart=always: a deterministically-failing ExecStartPre (prestart,
+# configure-container-routing, or an app-prestart.sh hook under set -e) must
+# terminate in `failed` instead of looping every RestartSec forever. With
+# RestartSec=10 a failing start trips the burst in ~40s, while a legitimate
+# in-app restart spaced further apart than interval/burst never accumulates.
+# A start-limit `failed` unit does not self-heal: after fixing the cause run
+# `systemctl reset-failed` then `systemctl start` (an upgrade will not clear it).
+StartLimitIntervalSec=600
+StartLimitBurst=5
 {% if is_oidc_app %}
 After=halos-authelia-container.service
 Wants=halos-authelia-container.service

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -674,3 +674,91 @@ class TestHalosDomainDistribution:
         assert "Wants=halos-resolve-domain.service" in service
         assert "EnvironmentFile=-/run/halos/domain.env" in service
         assert "halos-core-containers (>= 0.5.0)" in control
+
+
+class TestStartLimit:
+    """Generated units bound Restart=always with a start-rate limit so a
+    deterministically-failing prestart terminates in `failed` instead of
+    looping forever (issue #213)."""
+
+    template_dir = (
+        Path(__file__).parent.parent
+        / "src"
+        / "generate_container_packages"
+        / "templates"
+    )
+
+    def _render_service(self, tmp_path, metadata):
+        app_def = AppDefinition(
+            metadata=metadata,
+            compose={},
+            config={},
+            input_dir=Path("/test/dir"),
+            icon_path=None,
+        )
+        output_dir = tmp_path / "output"
+        render_all_templates(app_def, output_dir, self.template_dir)
+        pkg = metadata["package_name"]
+        return (output_dir / "debian" / f"{pkg}.service").read_text()
+
+    @staticmethod
+    def _plain_metadata():
+        return {
+            "name": "Plain App",
+            "package_name": "plain-app-container",
+            "app_id": "plain-app",
+            "version": "1.0.0",
+            "description": "App with no web UI or routing",
+            "maintainer": "Test <test@example.com>",
+            "license": "MIT",
+            "tags": ["role::container-app"],
+            "debian_section": "net",
+            "architecture": "all",
+        }
+
+    def test_unit_section_carries_start_limit(self, tmp_path):
+        """The [Unit] section sets both StartLimitIntervalSec and
+        StartLimitBurst so the restart rate is bounded."""
+        content = self._render_service(tmp_path, self._plain_metadata())
+
+        assert "StartLimitIntervalSec=600" in content
+        assert "StartLimitBurst=5" in content
+
+    def test_start_limit_terminates_deterministic_loop(self, tmp_path):
+        """With RestartSec=10, the burst must be reachable inside the interval
+        so a prestart that fails every restart trips the limit and the unit
+        enters `failed` (burst * RestartSec < interval)."""
+        content = self._render_service(tmp_path, self._plain_metadata())
+
+        interval = int(
+            next(
+                line.split("=", 1)[1]
+                for line in content.splitlines()
+                if line.startswith("StartLimitIntervalSec=")
+            )
+        )
+        burst = int(
+            next(
+                line.split("=", 1)[1]
+                for line in content.splitlines()
+                if line.startswith("StartLimitBurst=")
+            )
+        )
+        restart_sec = int(
+            next(
+                line.split("=", 1)[1]
+                for line in content.splitlines()
+                if line.startswith("RestartSec=")
+            )
+        )
+
+        assert burst * restart_sec < interval
+
+    def test_start_limit_directives_live_in_unit_section(self, tmp_path):
+        """StartLimit* are [Unit]-section directives; placing them under
+        [Service] makes systemd ignore them."""
+        content = self._render_service(tmp_path, self._plain_metadata())
+
+        unit_section = content.split("[Service]", 1)[0]
+        assert "StartLimitIntervalSec=600" in unit_section
+        assert "StartLimitBurst=5" in unit_section


### PR DESCRIPTION
## Motivation

Generated systemd units set `Restart=always` / `RestartSec=10` (`templates/systemd/service.j2`) with **no** `StartLimitIntervalSec`/`StartLimitBurst`. A deterministically-failing `ExecStartPre` — the framework `prestart.sh`, `configure-container-routing`, or (since the composable-prestart work) a failing app-`prestart.sh` hook sourced under `set -e` — makes systemd retry start every 10s **forever** instead of entering `failed`. On a device this is quiet log-spam/churn rather than an observable failure.

`Restart=always` itself is intentional: PR #199 set it specifically so an app can request its own restart (e.g. Signal K restarting itself). So the fix must bound the restart *rate* without breaking legitimate in-app restarts.

## Approach

Add to the `[Unit]` section of the generated unit:

```
StartLimitIntervalSec=600
StartLimitBurst=5
```

(`StartLimit*` are `[Unit]`-section directives — placing them under `[Service]` makes systemd ignore them; a test asserts they land in `[Unit]`.)

## Value justification

The two requirements — terminate a deterministic prestart failure in `failed`, yet survive legitimate infrequent in-app restarts — do not conflict, because they live on very different timescales. The chosen values separate them cleanly:

- **Why the systemd defaults don't work here.** systemd's defaults are `StartLimitIntervalSec=10s`, `StartLimitBurst=5`. With `RestartSec=10`, five starts span ~40s, which exceeds the 10s default window — so the limit **never trips** and the unit loops forever. Widening the interval is what actually makes the limit effective.
- **Deterministic prestart failure terminates fast.** A prestart that fails on every start restarts every `RestartSec=10`. Five starts accumulate in ~40s, well inside the 600s (10 min) window, so the unit hits the burst and enters `failed` after ~40s — observable via `systemctl status` / `is-failed` instead of silent churn.
- **Legitimate in-app restarts are safe.** The burst (5) over the interval (600s) tolerates a sustained restart rate of one per ~120s. An app deciding to restart itself does so on the order of minutes to hours apart, far below that threshold, so such restarts never accumulate toward the limit. A genuine flapping crash-loop (sub-2-min cadence) *should* trip the limit — that is the intended safety behavior, not a regression.

Net: `burst * RestartSec` (50s) `< interval` (600s) guarantees a same-cause loop is caught, while the per-restart budget of ~120s stays generous for intentional, infrequent restarts. A test asserts the `burst * RestartSec < interval` invariant directly so the values can't silently drift into ineffectiveness.

## Tests

TDD: added `TestStartLimit` in `tests/test_renderer.py` (asserts both directives are emitted, that they sit in the `[Unit]` section, and the `burst * RestartSec < interval` invariant). Confirmed red before the template change, green after. Full unit + integration suites, ruff lint/format, and `ty` all pass locally.

## Caveat

Per the workspace version-bump policy, version-cycle coordination is handled at merge by the orchestrator — this PR does **not** bump `VERSION` or edit `debian/changelog`. CI `version-bump-check` may therefore be red; that is expected and will be resolved at merge time.

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)