### PR TITLE
Fix prestart.sh exiting 1 when an app has no app-prestart.sh hook

### DIFF
--- a/src/generate_container_packages/prestart.py
+++ b/src/generate_container_packages/prestart.py
@@ -129,8 +129,15 @@ def generate_prestart_script(app_def: AppDefinition) -> str:
     lines.extend(
         [
             "",
-            "# Run app-specific prestart hook if present",
-            f'[ -f "{app_prestart}" ] && . "{app_prestart}"',
+            "# Run app-specific prestart hook if present. Use an if-block rather than",
+            "# `[ -f x ] && . x`: as the script's final command that test returns 1",
+            "# when the hook is absent, and under `set -e` that fails the systemd",
+            "# ExecStartPre so the container never starts. An if-block that takes no",
+            "# branch exits 0, while a sourced hook that itself fails still aborts",
+            "# via set -e.",
+            f'if [ -f "{app_prestart}" ]; then',
+            f'    . "{app_prestart}"',
+            "fi",
         ]
     )
 

--- a/tests/test_prestart.py
+++ b/tests/test_prestart.py
@@ -261,10 +261,15 @@ class TestGeneratePrestartScript:
         script = generate_prestart_script(app_def)
 
         hook = "/var/lib/container-apps/test-app-container/app-prestart.sh"
-        # Guarded source: [ -f <hook> ] && . <hook>
+        # Guarded source inside an if-block.
         assert hook in script
         assert f'[ -f "{hook}" ]' in script
         assert f'. "{hook}"' in script
+        # Regression: must NOT be the trailing `[ -f x ] && . x` one-liner. As the
+        # script's last command that returns 1 when the hook is absent, which under
+        # `set -e` fails ExecStartPre and the container never starts.
+        assert f'[ -f "{hook}" ] && . "{hook}"' not in script
+        assert f'if [ -f "{hook}" ]; then' in script
         # The hook is sourced after the LAST runtime.env write (not merely after
         # the RUNTIME_ENV declaration), so framework scaffolding is fully in place.
         assert script.rindex('>> "$RUNTIME_ENV"') < script.index(hook)


### PR DESCRIPTION
## Problem

The generated `prestart.sh` ends with the guarded one-liner:

```sh
[ -f "/var/lib/container-apps/<pkg>/app-prestart.sh" ] && . "/var/lib/container-apps/<pkg>/app-prestart.sh"
```

When the optional `app-prestart.sh` hook is **absent**, that `[ -f ]` test is the script's **final command** and returns `1`. Under `set -e` the script exits `1`, which fails the systemd `ExecStartPre` — so the container never starts, crash-loops until `StartLimitBurst`, and lands in `failed`.

Apps that ship an `app-prestart.sh` (e.g. OIDC apps) were unaffected, because the sourced hook returns `0`. Apps **without** one all die.

### Real-world impact

On a live HaLOS deployment a package upgrade using this generator took down **four** container apps at once (Music Assistant + three others), while Home Assistant and Signal K kept running — the difference being that those two ship an `app-prestart.sh`. The failure is silent (no output from `prestart.sh`), so it presents only as `Control process exited, code=exited, status=1/FAILURE` in the journal.

## Fix

Emit an `if`-block instead of the `&&` one-liner:

```sh
if [ -f "<hook>" ]; then
    . "<hook>"
fi
```

- Hook **absent** → the `if` takes no branch → exits `0`. ✅
- Hook **present and succeeds** → sources it, exits `0`. ✅
- Hook **present but fails** → `set -e` still aborts. ✅ (A blanket trailing `exit 0` would have masked a broken hook — this preserves fail-fast.)

## Tests

- Updated `test_sources_app_prestart_hook` with a regression assertion that the trailing `[ -f x ] && . x` one-liner is **not** emitted and the `if`-block form **is**.
- Full `tests/test_prestart.py` suite passes (20 passed).
- Verified the generated script is valid (`bash -n`) and the `if`-block exits `0` when the hook is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)