### PR TITLE
fix(prestart): source the app hook from an if-block so a missing hook is not a failure

### DIFF
--- a/src/generate_container_packages/prestart.py
+++ b/src/generate_container_packages/prestart.py
@@ -126,11 +126,16 @@ def generate_prestart_script(app_def: AppDefinition) -> str:
     # Source the optional app-specific hook last, with the framework scaffolding
     # (sourced env, $HALOS_DOMAIN, $RUNTIME_ENV) already in place. Absence is a
     # no-op; the hook must append to $RUNTIME_ENV, never truncate it.
+    # An if-block, not `[ -f x ] && . x`: as the script's final command that test
+    # returns 1 when the hook is absent, failing the systemd ExecStartPre. A
+    # branch not taken exits 0, while a hook that fails still aborts via set -e.
     lines.extend(
         [
             "",
             "# Run app-specific prestart hook if present",
-            f'[ -f "{app_prestart}" ] && . "{app_prestart}"',
+            f'if [ -f "{app_prestart}" ]; then',
+            f'    . "{app_prestart}"',
+            "fi",
         ]
     )
 

--- a/tests/test_prestart.py
+++ b/tests/test_prestart.py
@@ -261,13 +261,53 @@ class TestGeneratePrestartScript:
         script = generate_prestart_script(app_def)
 
         hook = "/var/lib/container-apps/test-app-container/app-prestart.sh"
-        # Guarded source: [ -f <hook> ] && . <hook>
         assert hook in script
-        assert f'[ -f "{hook}" ]' in script
         assert f'. "{hook}"' in script
         # The hook is sourced after the LAST runtime.env write (not merely after
         # the RUNTIME_ENV declaration), so framework scaffolding is fully in place.
         assert script.rindex('>> "$RUNTIME_ENV"') < script.index(hook)
+
+    def test_exits_zero_when_hook_absent(self, tmp_path):
+        """An app that ships no app-prestart.sh must still exit 0: the guard is
+        the script's final command, and a non-zero status fails the systemd
+        ExecStartPre so the container never starts."""
+        script = generate_prestart_script(_hook_app())
+
+        result = _run_prestart(script, tmp_path)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_failing_hook_aborts(self, tmp_path):
+        """Absence being a no-op must not be bought with a blanket `|| true` or
+        trailing `exit 0`: a hook that fails still has to fail the unit."""
+        hook = tmp_path / "var/lib/container-apps/test-app-container/app-prestart.sh"
+        hook.parent.mkdir(parents=True)
+        hook.write_text("exit 1\n")
+        script = generate_prestart_script(_hook_app())
+
+        result = _run_prestart(script, tmp_path)
+
+        assert result.returncode != 0
+
+
+def _hook_app() -> AppDefinition:
+    """Minimal app definition whose prestart sources the optional hook."""
+    app_def = mock.Mock(spec=AppDefinition)
+    app_def.metadata = {
+        "package_name": "test-app-container",
+        "name": "Test App",
+        "web_ui": {"enabled": True, "protocol": "http", "port": 8080},
+    }
+    return app_def
+
+
+def _run_prestart(script: str, tmp_path) -> subprocess.CompletedProcess[str]:
+    """Execute a generated prestart with its absolute paths rebased under tmp_path."""
+    if shutil.which("bash") is None:
+        pytest.skip("bash not available")
+    script_path = tmp_path / "prestart.sh"
+    script_path.write_text(script.replace('"/', f'"{tmp_path}/'))
+    return subprocess.run(["bash", str(script_path)], text=True, capture_output=True)
 
 
 class TestOidcSectionWiring:


### PR DESCRIPTION
## Motivation

The generated `prestart.sh` ends with `[ -f "<hook>" ] && . "<hook>"`. That guard is the script's *final* command, so when an app ships no `app-prestart.sh` the test's exit status 1 becomes the script's exit status. systemd's `ExecStartPre` fails, the unit crash-loops to `StartLimitBurst`, and the app lands in `failed` — silently, with nothing but `Control process exited, code=exited, status=1/FAILURE` in the journal.

Apps that do ship a hook were unaffected, because sourcing it leaves status 0 behind. That is why the failure looked selective in the field: @stigdreyer reported (#220) a package upgrade taking down four container apps at once while Home Assistant and Signal K, both of which ship hooks, kept running.

Note that `set -e` is not the mechanism here — a failing left-hand side of an `&&` list is explicitly exempt from `set -e`. The damage is done purely by the exit status of the last command.

## Approach

Emit an `if`-block instead of the `&&` one-liner. A branch not taken exits 0; a hook that fails still aborts the unit via `set -e`, which a blanket `|| true` or a trailing `exit 0` (the fix suggested in the issue) would have masked.

This is based on @stigdreyer's PR #219, which he opened and then closed himself — the approach is his; the inline comment is trimmed and its `set -e` reasoning corrected.

The regression is pinned behaviorally rather than by string-matching the emitted shell: both new tests generate the script, rebase its absolute paths under a tmp dir, execute it with bash, and assert the exit status — 0 with no hook installed, non-zero when the hook itself fails. The pre-existing `test_sources_app_prestart_hook` asserted the buggy `[ -f "<hook>" ]` form directly and was updated.

fixes #220
