### PR TITLE
test(prestart): make hook-failure propagation actually testable

### DIFF
--- a/tests/test_prestart.py
+++ b/tests/test_prestart.py
@@ -310,8 +310,18 @@ class TestPrestartExitStatus:
         assert self._run(tmp_path, "#!/bin/bash\ntrue\n").returncode == 0
 
     def test_hook_failure_still_propagates(self, tmp_path):
-        """Absence is a no-op, but a hook that fails must fail the start."""
-        assert self._run(tmp_path, "#!/bin/bash\nexit 3\n").returncode != 0
+        """Absence is a no-op, but a hook that fails must fail the start.
+
+        The hook fails without calling `exit`: `exit` inside a sourced file
+        terminates the parent shell regardless of how the source is guarded, so
+        it cannot tell `. <hook>` apart from `. <hook> || true`. A bare `false`
+        can -- under `||` bash suspends errexit for the whole sourced file, so
+        the hook would run to completion and the script would exit 0.
+        """
+        result = self._run(tmp_path, "#!/bin/bash\nfalse\necho reached\n")
+
+        assert result.returncode != 0
+        assert "reached" not in result.stdout
 
 
 class TestOidcSectionWiring:


### PR DESCRIPTION
`test_hook_failure_still_propagates` passes against the exact regression it is named for.

Its hook body is `exit 3`. `exit` inside a **sourced** file terminates the parent shell immediately — independent of `set -e`, of `|| true`, and of any trailing `exit 0`. So the test pins nothing about errexit propagation.

Demonstrated by mutation on current main. Emitting `. "{hook}" || true` from the generator, which is precisely the change the test exists to catch:

```
PYTHONPATH=src uv run pytest -q   ->  949 passed, 18 skipped
```

Fully green, including that test and the `. "<hook>"` substring assertion, which still matches inside the mutated line.

Only a hook that fails *without* calling `exit` discriminates. This changes the body to `false` followed by `echo reached`, and asserts both a non-zero return code and that `reached` never reaches stdout.

With the same mutation re-applied:

```
1 failed, 22 passed
AssertionError: assert 0 != 0
CompletedProcess(returncode=0, stdout='reached\n', stderr='')
```

Under `||`, bash suspends errexit for the sourced file, so `false` does not abort and `echo reached` runs. The test now catches that; reverted, it passes.

This matters because `AGENTS.md` states the contract as "the framework runs under `set -e`, so a failing hook command aborts unit start." Nothing was pinning it. A hook whose command fails without exiting — a failing `grep`, a missing binary, `openssl … > secret` on a full disk — would be silently swallowed and the container would start with a half-written `runtime.env`.

Test-only. The generator is unchanged and already correct.

Surfaced while reviewing #231, which is closed as superseded by 9448e75.

`./run test` is 958 passed with 5 pre-existing failures in `tests/test_package_install.py` (tracked in #229); `tests/test_prestart.py` is 23/23.

---
*Investigated and drafted with [Claude Code](https://claude.com/claude-code).*
